### PR TITLE
Changed Alaska Tsunami Warning center to National Tsunami Warning Center...

### DIFF
--- a/src/htdocs/modules/summary/0-0-1/js/Attribution.js
+++ b/src/htdocs/modules/summary/0-0-1/js/Attribution.js
@@ -23,7 +23,7 @@ define([
 
 	var SOURCE_MAP = {
 		'AK,AEIC': {id: 'AK,AEIC', 'title': 'Alaska Earthquake Information Center', 'url': 'http://www.aeic.alaska.edu/', 'logo': LOGO_ROOT + 'AK.jpg'},
-		'AT,ATWC': {id: 'AT,ATWC', 'title': 'National Tsunami Warning Center', 'url': 'ntwc.arh.noaa.gov', 'logo': LOGO_ROOT + 'PT.jpg'},
+		'AT,ATWC': {id: 'AT,ATWC', 'title': 'National Tsunami Warning Center', 'url': 'http://ntwc.arh.noaa.gov', 'logo': LOGO_ROOT + 'PT.jpg'},
 		'CI': {id: 'CI', 'title': 'Southern California Seismic Network, Caltech, USGS Pasadena, and Partners', 'url': 'http://www.cisn.org/', 'logo': LOGO_ROOT + 'CI.gif'},
 		'HV': {id: 'HV', 'title': 'Hawaii Volcano Observatory', 'url': 'http://hvo.wr.usgs.gov/', 'logo': ''},
 		'LD': {id: 'LD', 'title': 'Lamont-Doherty Cooperative Seismographic Network', 'url': 'http://www.ldeo.columbia.edu/LCSN/', 'logo': ''},


### PR DESCRIPTION
..., Changed link for Alaska Tsunami warning as well.
