### PR TITLE
turned on zoom animation

### DIFF
--- a/src/htdocs/modules/summary/0-0-1/js/InteractiveMap.js
+++ b/src/htdocs/modules/summary/0-0-1/js/InteractiveMap.js
@@ -63,7 +63,7 @@ define([
     this._map = map = new L.Map(_el, {
       center: [0.0, 0.0],
       zoom: 2,
-      zoomAnimation: false,
+      zoomAnimation: true,
       attributionControl: false
     });
 


### PR DESCRIPTION
Turned on zoom animations, this fixes layers disappearing on touch devices during pinch zooming.
