### PR TITLE
Update styles for tectonic summary thumbnails

### DIFF
--- a/src/htdocs/modules/summary/_TectonicSummary.scss
+++ b/src/htdocs/modules/summary/_TectonicSummary.scss
@@ -8,6 +8,7 @@ $baseImageUrl: 'http://earthquake.usgs.gov/earthquakes/tectonic/images';
     margin: 1em 0 1em;
     width: 304px;
     position:relative;
+    background-repeat: no-repeat;
 
     &:after{
       content:'Map of Tectonic Summary Region';
@@ -25,7 +26,7 @@ $baseImageUrl: 'http://earthquake.usgs.gov/earthquakes/tectonic/images';
 
   a.aleutian {
     background-image:url('#{$baseImageUrl}/aleutian_tsum304.jpg');
-    height:204px;
+    height:196px;
   }
 
 


### PR DESCRIPTION
Fix css that displays thumbnails of tectonic summary posters

Example of problem:
http://earthquake.usgs.gov/earthquakes/eventpage/ak11639524#general_summary