### PR TITLE
Improve error handling for station list data on shakemap page

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "hazdev-svgimagemap": "~0.0.4",
     "hazdev-tablist": "~0.1.0",
     "hazdev-template": "~0.2.1",
-    "hazdev-webutils": "~0.1.0",
+    "hazdev-webutils": "~0.1.6",
     "ini": "^1.2.1",
     "leaflet": "^0.7.0",
     "mocha": "^2.1.0",

--- a/src/htdocs/modules/impact/ShakeMapPage.js
+++ b/src/htdocs/modules/impact/ShakeMapPage.js
@@ -251,7 +251,7 @@ ShakeMapPage.prototype._getStationData = function (callback, errback) {
     success: function (data) {
       callback(data);
     },
-    error: function (msg, e) {
+    error: function (e /*, xhr*/) {
       errback('Unable to retreive the station list.');
       console.log(e.stack);
     }

--- a/src/htdocs/modules/impact/ShakeMapPage.js
+++ b/src/htdocs/modules/impact/ShakeMapPage.js
@@ -251,9 +251,9 @@ ShakeMapPage.prototype._getStationData = function (callback, errback) {
     success: function (data) {
       callback(data);
     },
-    error: function (e) {
+    error: function (msg, e) {
       errback('Unable to retreive the station list.');
-      console.log(e);
+      console.log(e.stack);
     }
   });
 };

--- a/src/htdocs/modules/impact/ShakeMapPage.js
+++ b/src/htdocs/modules/impact/ShakeMapPage.js
@@ -216,7 +216,7 @@ ShakeMapPage.prototype._addStationList = function () {
             });
           },
           function (errorMessage) {
-            container.innerHTML = '<p class="error">' + errorMessage + '</p>';
+            container.innerHTML = '<p class="alert error">' + errorMessage + '</p>';
           }
       );
       // return panel content
@@ -251,8 +251,9 @@ ShakeMapPage.prototype._getStationData = function (callback, errback) {
     success: function (data) {
       callback(data);
     },
-    error: function () {
-      errback('Error: Unable to retreive the station list.');
+    error: function (e) {
+      errback('Unable to retreive the station list.');
+      console.log(e);
     }
   });
 };


### PR DESCRIPTION
Add "alert" class to the error message and log the caught exception in the ajax request

depends on https://github.com/usgs/hazdev-webutils/pull/73
fixes https://github.com/usgs/earthquake-eventpages/issues/239