### PR TITLE
Issue 219

### DIFF
--- a/gruntconfig/browserify.js
+++ b/gruntconfig/browserify.js
@@ -13,6 +13,7 @@ var BUNDLED_DEPENDENCIES = [
   './' + config.src + '/htdocs/modules/base/Formatter.js:base/Formatter',
   './' + config.src + '/htdocs/modules/base/ImpactUtil.js:base/ImpactUtil',
   './' + config.src + '/htdocs/modules/base/SummaryDetailsPage.js:base/SummaryDetailsPage',
+  './' + config.src + '/htdocs/modules/base/SummaryPage.js:base/SummaryPage',
   NODE_MODULES + '/hazdev-accordion/src/accordion/Accordion.js:accordion/Accordion',
   NODE_MODULES + '/hazdev-tablist/src/tablist/TabList.js:tablist/TabList',
   NODE_MODULES + '/hazdev-webutils/src/mvc/Collection.js:mvc/Collection',

--- a/gruntconfig/browserify.js
+++ b/gruntconfig/browserify.js
@@ -10,6 +10,7 @@ var CWD = process.cwd(),
 var BUNDLED_DEPENDENCIES = [
   './' + config.src + '/htdocs/modules/base/Attribution.js:base/Attribution',
   './' + config.src + '/htdocs/modules/base/EventModulePage.js:base/EventModulePage',
+  './' + config.src + '/htdocs/modules/base/EventUtil.js:base/EventUtil',
   './' + config.src + '/htdocs/modules/base/Formatter.js:base/Formatter',
   './' + config.src + '/htdocs/modules/base/ImpactUtil.js:base/ImpactUtil',
   './' + config.src + '/htdocs/modules/base/SummaryDetailsPage.js:base/SummaryDetailsPage',

--- a/src/htdocs/css/index.scss
+++ b/src/htdocs/css/index.scss
@@ -33,13 +33,6 @@ canvas {
   margin: 1em 0 0;
 }
 
-.attribution {
-  color: #666;
-  display: block;
-  font-size: .75em;
-  font-weight: normal;
-}
-
 
 .leaflet-control-layers-toggle {
   /** important since loads before modules that include leaflet base styles. */

--- a/src/htdocs/modules/base/EventModule.js
+++ b/src/htdocs/modules/base/EventModule.js
@@ -252,25 +252,24 @@ EventModule.prototype.getHeaderMarkup = function (page) {
       isReviewed = (isReviewed.toUpperCase() === 'REVIEWED');
     }
 
-    Array.prototype.push.apply(markup, [
+    markup.push(
       page.getAttribution(product),
 
       '<ul class="quality-statements no-style">',
         '<li class="', isPreferred ? 'preferred' : 'unpreferred', '">',
           'The data below is ', isPreferred ? '' : '<strong>NOT</strong> ',
           'the most preferred data available.',
-        '</li>',
-    ]);
+        '</li>'
+    );
 
     if (product.properties.hasOwnProperty('review-status')) {
-      Array.prototype.push.apply(markup,
-        [
+      markup.push(
           '<li class="', isReviewed ? 'reviewed' : 'unreviewed', '">',
             'The data below has ', isReviewed ? '' : '<strong>NOT</strong> ',
             'been reviewed by a scientist.',
           '</li>',
         '</ul>'
-      ]);
+      );
     } else {
       markup.push('</ul>');
     }

--- a/src/htdocs/modules/base/EventModule.js
+++ b/src/htdocs/modules/base/EventModule.js
@@ -218,7 +218,65 @@ EventModule.prototype._eventHasProduct = function (type) {
 };
 
 EventModule.prototype.getHeaderMarkup = function (page) {
-  return '<h2>' + this._title + ' - ' + page.getTitle() + '</h2>';
+  var isPreferred,
+      isReviewed,
+      markup,
+      product,
+      products,
+      subtitle,
+      title;
+
+  title = this._title;
+  subtitle = page.getTitle();
+
+  products = page.getProducts();
+  product = page.getProductToRender();
+
+
+
+  markup = [
+    '<h2>' + title + ' - ' + subtitle + '</h2>',
+
+    '<a class="back-to-summary-link" href="#', this.getHash(), '_summary">',
+      (products.length < 2) ?
+          'Back to ' + title + ' Summary' :
+          'View all ' + subtitle + 's (' + products.length + ' total)',
+    '</a>'
+  ];
+
+  if (product && products.length) {
+    isPreferred = product.id === products[0].id;
+
+    isReviewed = product.properties['review-status'];
+    if (isReviewed) {
+      isReviewed = (isReviewed.toUpperCase() === 'REVIEWED');
+    }
+
+    Array.prototype.push.apply(markup, [
+      page.getAttribution(product),
+
+      '<ul class="quality-statements no-style">',
+        '<li class="', isPreferred ? 'preferred' : 'unpreferred', '">',
+          'The data below is ', isPreferred ? '' : '<strong>NOT</strong> ',
+          'the most preferred data available.',
+        '</li>',
+    ]);
+
+    if (product.properties.hasOwnProperty('review-status')) {
+      Array.prototype.push.apply(markup,
+        [
+          '<li class="', isReviewed ? 'reviewed' : 'unreviewed', '">',
+            'The data below has ', isReviewed ? '' : '<strong>NOT</strong> ',
+            'been reviewed by a scientist.',
+          '</li>',
+        '</ul>'
+      ]);
+    } else {
+      markup.push('</ul>');
+    }
+  };
+
+  return markup.join('');
 };
 
 EventModule.prototype.getFooterMarkup = function (/* page */) {

--- a/src/htdocs/modules/base/EventModule.js
+++ b/src/htdocs/modules/base/EventModule.js
@@ -274,7 +274,7 @@ EventModule.prototype.getHeaderMarkup = function (page) {
     } else {
       markup.push('</ul>');
     }
-  };
+  }
 
   return markup.join('');
 };

--- a/src/htdocs/modules/base/EventModule.js
+++ b/src/htdocs/modules/base/EventModule.js
@@ -136,7 +136,7 @@ EventModule.prototype._getNavigationItem = function (page, hash, force) {
   if (this._pageHasContent(page)) {
     item.push('<a href="#' + fullHash + '">');
 
-    if (fullHash === hash) {
+    if (hash.indexOf(fullHash) !== -1) {
       item.push('<strong class="current-page">' + linkText + '</strong>');
     } else {
       item.push(linkText);
@@ -146,7 +146,7 @@ EventModule.prototype._getNavigationItem = function (page, hash, force) {
   } else if (force) {
     item.push('<a href="javascript:void(null);">');
 
-    if (fullHash === hash) {
+    if (hash.indexOf(fullHash) !== -1) {
       item.push('<strong class="current-page">' + linkText + '</strong>');
     } else {
       item.push(linkText);

--- a/src/htdocs/modules/base/EventModulePage.js
+++ b/src/htdocs/modules/base/EventModulePage.js
@@ -52,6 +52,10 @@ EventModulePage.prototype.destroy = function () {
   // TODO
 };
 
+EventModulePage.prototype.getAttribution = function (product) {
+  return EventUtil.getAttribution(product || this.getProductToRender());
+};
+
 EventModulePage.prototype.getHeader = function () {
   return this._header;
 };

--- a/src/htdocs/modules/base/EventModulePage.js
+++ b/src/htdocs/modules/base/EventModulePage.js
@@ -215,13 +215,14 @@ EventModulePage.prototype._setFooterMarkup = function () {
 };
 
 EventModulePage.prototype.setDownloadMarkup = function () {
-  var products,
-      el;
-  //Get a list of products to add to the downloads list.
-  products = this.getProducts();
+  var el,
+      product;
+
+  //Get a product to add to the downloads list.
+  product = this.getProductToRender();
 
   //IRIS page, and tests can return no products.
-  if (products.length !== 0) {
+  if (product) {
 
     el = document.createElement('section');
     new Accordion({
@@ -242,20 +243,16 @@ EventModulePage.prototype.setDownloadMarkup = function () {
 };
 
 EventModulePage.prototype.loadDownloadMarkup = function (e) {
-  var products = this.getProducts(),
-      product,
-      i;
+  var product = this.getProductToRender();
 
   e.preventDefault();
   this._downloadsEl.removeEventListener('click',this.loadDownloadMarkup);
 
-  for (i=0; i< products.length; i++) {
-    product = products[i];
-    if (product.phasedata) {
-      product = product.phasedata;
-    }
-    this.getDownloads(product);
+  if (product.phasedata) {
+    product = product.phasedata;
   }
+
+  this.getDownloads(product);
 };
 
 /**

--- a/src/htdocs/modules/base/EventPage.js
+++ b/src/htdocs/modules/base/EventPage.js
@@ -36,9 +36,9 @@ var REDIRECTS = {
 
   'scientific': 'scientific_summary',
   'scientific_contributed-solutions': 'scientific_origin',
-  'scientific_moment-tensor': 'scientific_tensor',
-  'scientific_focal-mechanism': 'scientific_mechanism',
-  'scientific_finite-fault': 'scientific_finitefault'
+  'scientific_tensor': 'scientifi_moment-tensor',
+  'scientific_mechanism': 'scientific_focal-mechanism',
+  'scientific_finitefault': 'scientific_finite-fault'
 };
 
 var DEFAULTS = {

--- a/src/htdocs/modules/base/EventPage.js
+++ b/src/htdocs/modules/base/EventPage.js
@@ -36,7 +36,7 @@ var REDIRECTS = {
 
   'scientific': 'scientific_summary',
   'scientific_contributed-solutions': 'scientific_origin',
-  'scientific_tensor': 'scientifi_moment-tensor',
+  'scientific_tensor': 'scientific_moment-tensor',
   'scientific_mechanism': 'scientific_focal-mechanism',
   'scientific_finitefault': 'scientific_finite-fault'
 };

--- a/src/htdocs/modules/base/EventUtil.js
+++ b/src/htdocs/modules/base/EventUtil.js
@@ -1,7 +1,14 @@
 'use strict';
 
+var Attribution = require('base/Attribution'),
+    Formatter = require('base/Formatter');
+
+
+var _formatter = new Formatter();
 
 var _getOriginProducts,
+
+    getAttribution,
     getCodeFromHash,
     getProducts;
 
@@ -47,6 +54,17 @@ _getOriginProducts = function (allProducts) {
 };
 
 
+getAttribution = function (product) {
+  if (product) {
+    return '<small class="attribution">Data source ' +
+      Attribution.getContributorReference(product.source) +
+      ' last updated ' + _formatter.datetime(product.updateTime, 0) +
+    '</small>';
+  } else {
+    return '';
+  }
+};
+
 getCodeFromHash = function () {
   var parts;
 
@@ -73,6 +91,7 @@ getProducts = function (eventDetails, type) {
 };
 
 module.exports = {
+  getAttribution: getAttribution,
   getCodeFromHash: getCodeFromHash,
   getProducts: getProducts
 };

--- a/src/htdocs/modules/base/EventUtil.js
+++ b/src/htdocs/modules/base/EventUtil.js
@@ -1,0 +1,78 @@
+'use strict';
+
+
+var _getOriginProducts,
+    getCodeFromHash,
+    getProducts;
+
+
+_getOriginProducts = function (allProducts) {
+  var origins,
+      phases,
+      productIndex,
+      products;
+
+  productIndex = [];
+  products = [];
+
+  origins = allProducts.origin || [];
+  phases = allProducts['phase-data'] || [];
+
+  // Build a lookup index for existing origins
+  origins.forEach(function (origin) {
+    products.push(JSON.parse(JSON.stringify(origin)));
+    productIndex.push(origin.source + '_' + origin.code);
+  });
+
+  // Check phases, add phases that don't have a corresponding origin, or
+  // attach phase product to corresponding existing origins
+  phases.forEach(function (phase) {
+    var phaseId,
+        index;
+
+    phaseId = phase.source + '_' + phase.code;
+    index = productIndex.indexOf(phaseId);
+
+    if (index === -1) {
+      products.push(JSON.parse(JSON.stringify(phase)));
+      productIndex.push(phaseId);
+    } else {
+      if (products[index].updateTime <= phase.updateTime) {
+        products[index].phasedata = JSON.parse(JSON.stringify(phase));
+      }
+    }
+  });
+
+  return products;
+};
+
+
+getCodeFromHash = function () {
+  var parts;
+
+  parts = window.location.hash.split(':');
+
+  if (parts.length >= 2) {
+    return parts[1];
+  } else {
+    return null;
+  }
+};
+
+
+getProducts = function (eventDetails, type) {
+  var products;
+
+  if (type === 'origin' || type === 'phase-data') {
+    products = _getOriginProducts(eventDetails.properties.products);
+  } else {
+    products = eventDetails.properties.products[type];
+  }
+
+  return products || [];
+};
+
+module.exports = {
+  getCodeFromHash: getCodeFromHash,
+  getProducts: getProducts
+};

--- a/src/htdocs/modules/base/Formatter.js
+++ b/src/htdocs/modules/base/Formatter.js
@@ -27,6 +27,35 @@ var Formatter = function (options) {
   this._options = Util.extend({}, DEFAULTS, options);
 };
 
+
+Formatter.prototype.angle = function (angle, decimals) {
+  var value;
+
+  if (!angle && angle !== 0) {
+    return '&ndash;';
+  }
+
+  if (typeof decimals === 'number') {
+    value = Number(angle).toFixed(decimals);
+  } else {
+    value = Math.round(angle) + '&deg;';
+  }
+
+  return value + '&deg;';
+};
+
+Formatter.prototype.fmStrike = function (strike) {
+  return this.angle(strike, 0);
+};
+
+Formatter.prototype.fmDip = function (dip) {
+  return this.angle(dip, 0);
+};
+
+Formatter.prototype.fmRake = function (rake) {
+  return this.angle(rake, 0);
+};
+
 /**
  * Format a number.
  *

--- a/src/htdocs/modules/base/ProductSummarizer.js
+++ b/src/htdocs/modules/base/ProductSummarizer.js
@@ -377,22 +377,27 @@ getMomentTensorSummary = function (product) {  var beachBall,
  */
 getOriginSummary = function (product) {
   var depth,
+      location,
       magnitude,
       magnitudeSource,
       magnitudeType,
       originSource,
       p,
-      reviewStatus;
+      reviewStatus,
+      time;
 
   if (!product) {
     return '<p class="alert error">No origin product found for this event.</p>';
   }
 
   p = product.properties;
-  depth = p.depth;
+  depth = _formatter.depth(p.depth, 'km');
   magnitude = p.magnitude;
   magnitudeType = p['magnitude-type'];
+  time = _formatter.time(new Date(Date.parse(p.eventtime)));
   reviewStatus = p['review-status'] || 'automatic';
+  location = _formatter.location(parseFloat(p.latitude),
+      parseFloat(p.longitude));
   originSource = p['origin-source'] || product.source;
   magnitudeSource = p['magnitude-source'] || product.source;
 
@@ -406,12 +411,20 @@ getOriginSummary = function (product) {
         '<abbr title="Magnitude and Type">', magnitudeType, '</abbr>',
       '</li>',
       '<li>',
+        '<span>', time, '</span>',
+        '<abbr title="UTC Time">Time</abbr>',
+      '</li>',
+      '<li>',
         '<span>', depth, '</span>',
-        '<abbr title="Depth (km)">Depth (km)</abbr>',
+        '<abbr title="Depth">Depth</abbr>',
       '</li>',
       '<li>',
         '<span>', reviewStatus, '</span>',
         '<abbr title="Review Status">Status</abbr>',
+      '</li>',
+      '<li>',
+        '<span>', location, '</span>',
+        '<abbr title="Location Coordinates">Location</abbr>',
       '</li>',
       '<li>',
         EventModulePage.prototype.getCatalogSummary.call(null, product),

--- a/src/htdocs/modules/base/SummaryPage.js
+++ b/src/htdocs/modules/base/SummaryPage.js
@@ -136,6 +136,7 @@ SummaryPage.prototype._setHeaderMarkup = function () {
 
 SummaryPage.prototype._setContentMarkup = function () {
   var markup,
+      products,
       type,
       types;
 
@@ -143,11 +144,15 @@ SummaryPage.prototype._setContentMarkup = function () {
   types = this._options.includeTypes;
 
   for (type in types) {
-    markup.appendChild(_getTypeSummary({
-      info: types[type],
-      products: this.getProducts(type),
-      type: type
-    }));
+    products = this.getProducts(type);
+
+    if (products.length > 0) {
+      markup.appendChild(_getTypeSummary({
+        info: types[type],
+        products: products,
+        type: type
+      }));
+    }
   }
 
   this._content.innerHTML = '';

--- a/src/htdocs/modules/base/SummaryPage.js
+++ b/src/htdocs/modules/base/SummaryPage.js
@@ -75,17 +75,11 @@ var _getTableHeaders = function (params) {
 
 
 var _getTableRow = function (params) {
-  var product;
-
-  product = params.product;
+  params.formatter = params.formatter || _FORMATTER;
 
   return '<tr class="' + (params.preferred ? 'preferred' : '') + '">' +
     params.columns.reduce(function (prev, column) {
-      return prev + '<td>' + column.value({
-        product: product,
-        formatter: _FORMATTER,
-        preferred: params.preferred
-      }) + '</td>';
+      return prev + '<td>' + column.value(params) + '</td>';
   }, '') + '</tr>';
 };
 

--- a/src/htdocs/modules/base/SummaryPage.js
+++ b/src/htdocs/modules/base/SummaryPage.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var EventModulePage = require('base/EventModulePage'),
+    EventUtil = require('base/EventUtil'),
     Formatter = require('base/Formatter'),
 
     Util = require('util/Util');
@@ -26,46 +27,6 @@ var _DEFAULTS = {
 
 var _FORMATTER = new Formatter();
 
-
-var _getOriginProducts = function (allProducts) {
-  var origins,
-      phases,
-      productIndex,
-      products;
-
-  productIndex = [];
-  products = [];
-
-  origins = allProducts.origin || [];
-  phases = allProducts['phase-data'] || [];
-
-  // Build a lookup index for existing origins
-  origins.forEach(function (origin) {
-    products.push(JSON.parse(JSON.stringify(origin)));
-    productIndex.push(origin.source + '_' + origin.code);
-  });
-
-  // Check phases, add phases that don't have a corresponding origin, or
-  // attach phase product to corresponding existing origins
-  phases.forEach(function (phase) {
-    var phaseId,
-        index;
-
-    phaseId = phase.source + '_' + phase.code;
-    index = productIndex.indexOf(phaseId);
-
-    if (index === -1) {
-      products.push(JSON.parse(JSON.stringify(phase)));
-      productIndex.push(phaseId);
-    } else {
-      if (products[index].updateTime <= phase.updateTime) {
-        products[index].phasedata = JSON.parse(JSON.stringify(phase));
-      }
-    }
-  });
-
-  return products;
-};
 
 var _getTableHeaders = function (params) {
   return '<tr>' + params.columns.reduce(function (prev, column) {
@@ -160,15 +121,7 @@ SummaryPage.prototype._setContentMarkup = function () {
 };
 
 SummaryPage.prototype.getProducts = function (type) {
-  var products;
-
-  if (type === 'origin' || type === 'phase-data') {
-    products = _getOriginProducts(this._event.properties.products);
-  } else {
-    products = this._event.properties.products[type];
-  }
-
-  return products || [];
+  return EventUtil.getProducts(this._event, type);
 };
 
 

--- a/src/htdocs/modules/base/SummaryPage.js
+++ b/src/htdocs/modules/base/SummaryPage.js
@@ -1,0 +1,176 @@
+'use strict';
+
+var EventModulePage = require('base/EventModulePage'),
+    Formatter = require('base/Formatter'),
+
+    Util = require('util/Util');
+
+
+var _DEFAULTS = {
+  title: 'Summary',
+  hash: 'summary',
+  includeTypes: {
+    /*
+    type: {
+      display: {String},
+      columns: [
+        {
+          label: {String},
+          value: {Function}
+        },...
+      ]
+    }, ...
+    */
+  }
+};
+
+var _FORMATTER = new Formatter();
+
+
+var _getOriginProducts = function (allProducts) {
+  var origins,
+      phases,
+      productIndex,
+      products;
+
+  productIndex = [];
+  products = [];
+
+  origins = allProducts.origin || [];
+  phases = allProducts['phase-data'] || [];
+
+  // Build a lookup index for existing origins
+  origins.forEach(function (origin) {
+    products.push(JSON.parse(JSON.stringify(origin)));
+    productIndex.push(origin.source + '_' + origin.code);
+  });
+
+  // Check phases, add phases that don't have a corresponding origin, or
+  // attach phase product to corresponding existing origins
+  phases.forEach(function (phase) {
+    var phaseId,
+        index;
+
+    phaseId = phase.source + '_' + phase.code;
+    index = productIndex.indexOf(phaseId);
+
+    if (index === -1) {
+      products.push(JSON.parse(JSON.stringify(phase)));
+      productIndex.push(phaseId);
+    } else {
+      if (products[index].updateTime <= phase.updateTime) {
+        products[index].phasedata = JSON.parse(JSON.stringify(phase));
+      }
+    }
+  });
+
+  return products;
+};
+
+var _getTableHeaders = function (params) {
+  return '<tr>' + params.columns.reduce(function (prev, column) {
+    return prev + '<th scope="col">' + column.label + '</th>';
+  }, '') + '</tr>';
+};
+
+
+var _getTableRow = function (params) {
+  var product;
+
+  product = params.product;
+
+  return '<tr class="' + (params.preferred ? 'preferred' : '') + '">' +
+    params.columns.reduce(function (prev, column) {
+      return prev + '<td>' + column.value({
+        product: product,
+        formatter: _FORMATTER,
+        preferred: params.preferred
+      }) + '</td>';
+  }, '') + '</tr>';
+};
+
+var _getTableRows = function (params) {
+  return params.products.reduce(function (prev, product, index) {
+    return prev + _getTableRow({
+      product: product.phasedata || product,
+      columns: params.columns,
+      preferred: (index === 0)
+    });
+  }, '');
+};
+
+var _getTypeSummary = function (params) {
+  var header,
+      info,
+      summary,
+      table;
+
+  summary = document.createDocumentFragment();
+  info = params.info;
+
+  header = summary.appendChild(document.createElement('h2'));
+  header.innerHTML = info.display;
+
+  table = summary.appendChild(document.createElement('div'));
+  table.classList.add('horizontal-scrolling');
+  table.innerHTML = [
+    '<table class="table-summary">',
+      '<thead>',
+        _getTableHeaders(info),
+      '</thead>',
+      '<tbody>',
+        _getTableRows({products: params.products, columns: info.columns}),
+      '</tbody>',
+    '</table>'
+  ].join('');
+
+  return summary;
+};
+
+
+var SummaryPage = function (options) {
+  this._options = Util.extend({}, _DEFAULTS, options);
+  EventModulePage.call(this, this._options);
+};
+
+SummaryPage.prototype = Object.create(EventModulePage.prototype);
+
+
+SummaryPage.prototype._setHeaderMarkup = function () {
+  // Do nothing, no header on summary pages.
+};
+
+SummaryPage.prototype._setContentMarkup = function () {
+  var markup,
+      type,
+      types;
+
+  markup = document.createDocumentFragment();
+  types = this._options.includeTypes;
+
+  for (type in types) {
+    markup.appendChild(_getTypeSummary({
+      info: types[type],
+      products: this.getProducts(type),
+      type: type
+    }));
+  }
+
+  this._content.innerHTML = '';
+  this._content.appendChild(markup);
+};
+
+SummaryPage.prototype.getProducts = function (type) {
+  var products;
+
+  if (type === 'origin' || type === 'phase-data') {
+    products = _getOriginProducts(this._event.properties.products);
+  } else {
+    products = this._event.properties.products[type];
+  }
+
+  return products || [];
+};
+
+
+module.exports = SummaryPage;

--- a/src/htdocs/modules/base/_EventModule.scss
+++ b/src/htdocs/modules/base/_EventModule.scss
@@ -1,0 +1,43 @@
+.back-to-summary-link {
+  font-size: .75em;
+}
+
+.attribution {
+  color: #666;
+  display: block;
+  font-size: .75em;
+  font-weight: normal;
+  margin-top: .5em;
+}
+
+.quality-statements {
+  color: #999;
+  font-size: .75em;
+  margin-top: 0;
+
+  > li {
+    padding-left: 1.25em;
+    position: relative;
+
+    &:before {
+      display: block;
+      font-family: 'Material Icons';
+      left: 0;
+      margin-right: .25em;
+      position: absolute;
+      width: 1em;
+    }
+
+    &.preferred:before,
+    &.reviewed:before {
+      color: #090;
+      content: '\0e5ca';
+    }
+
+    &.unpreferred:before,
+    &.unreviewed:before {
+      color: #F90;
+      content: '\e888';
+    }
+  }
+}

--- a/src/htdocs/modules/base/_ProductSummarizer.scss
+++ b/src/htdocs/modules/base/_ProductSummarizer.scss
@@ -31,7 +31,7 @@
       max-width: 150px;
       text-align: center;
       vertical-align: middle;
-      width: 25%;
+      min-width: 33%;
 
       &.image > img {
         display: block;
@@ -99,6 +99,7 @@
   .summary > ul {
     > li {
       font-size: 1.125em;
+      min-width: 20%;
     }
   }
 }

--- a/src/htdocs/modules/base/_SummaryPage.scss
+++ b/src/htdocs/modules/base/_SummaryPage.scss
@@ -13,6 +13,10 @@
       color: #999;
       white-space: nowrap;
 
+      > img {
+        max-height: 3em;
+      }
+
       &:first-child {
         padding-left: 2.25em;
       }

--- a/src/htdocs/modules/base/_SummaryPage.scss
+++ b/src/htdocs/modules/base/_SummaryPage.scss
@@ -1,0 +1,33 @@
+.table-summary {
+  > tbody {
+    > tr > td {
+      color: #999;
+      white-space: nowrap;
+
+      &:first-child {
+        padding-left: 2.25em;
+      }
+    }
+
+    > tr:hover > td {
+      background-color: rgba(0,0,0,0.02);
+    }
+    > .preferred {
+      > td {
+        color: #333;
+
+        &:first-child {
+          padding-left: 0.75em;
+        }
+
+        > .material-icons {
+          color: #090;
+          font-weight: bold;
+          display: inline-block;
+          margin-right: .5em;
+          font-size: 1em;
+        }
+      }
+    }
+  }
+}

--- a/src/htdocs/modules/base/_SummaryPage.scss
+++ b/src/htdocs/modules/base/_SummaryPage.scss
@@ -1,4 +1,13 @@
 .table-summary {
+  > thead {
+    > tr th {
+
+      > small {
+        color: #666;
+        font-weight: normal;
+      }
+    }
+  }
   > tbody {
     > tr > td {
       color: #999;

--- a/src/htdocs/modules/base/index.scss
+++ b/src/htdocs/modules/base/index.scss
@@ -1,3 +1,4 @@
 /* This file should import partials for the base module/modulepages. */
 
 @import '_ProductSummarizer.scss';
+@import '_SummaryPage.scss';

--- a/src/htdocs/modules/base/index.scss
+++ b/src/htdocs/modules/base/index.scss
@@ -1,4 +1,5 @@
 /* This file should import partials for the base module/modulepages. */
 
+@import '_EventModule.scss';
 @import '_ProductSummarizer.scss';
 @import '_SummaryPage.scss';

--- a/src/htdocs/modules/impact/DYFIPage.js
+++ b/src/htdocs/modules/impact/DYFIPage.js
@@ -208,7 +208,7 @@ DYFIPage.prototype.destroy = function () {
     this._tablist.destroy();
     this._tablist = null;
   }
-  if (this._button !== null) {
+  if (this._button) {
     this._button.removeEventListener('click', this._onToggleButtonClick);
     this._button = null;
     this._onToggleButtonClick = null;
@@ -230,10 +230,7 @@ DYFIPage.prototype.getDetailsContent = function (dyfi) {
   this._dyfi = dyfi;
 
   el.classList.add('dyfi');
-  el.innerHTML = '<small class="attribution">Data Source ' +
-      Attribution.getContributorReference(dyfi.source) +
-      '</small>' +
-      '<div class="dyfi-tablist"></div>';
+  el.innerHTML = '<div class="dyfi-tablist"></div>';
 
   // Tablist element
   tablistDiv = el.querySelector('.dyfi-tablist');

--- a/src/htdocs/modules/impact/DYFIPage.js
+++ b/src/htdocs/modules/impact/DYFIPage.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var Attribution = require('base/Attribution'),
-    Collection = require('mvc/Collection'),
+var Collection = require('mvc/Collection'),
     DataTable = require('mvc/DataTable'),
     Formatter = require('base/Formatter'),
     ProductSummarizer = require('base/ProductSummarizer'),

--- a/src/htdocs/modules/impact/PagerPage.js
+++ b/src/htdocs/modules/impact/PagerPage.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var Attribution = require('base/Attribution'),
-    PagerXmlParser = require('./PagerXmlParser'),
+var PagerXmlParser = require('./PagerXmlParser'),
     ProductSummarizer = require('base/ProductSummarizer'),
     SummaryDetailsPage = require('base/SummaryDetailsPage'),
     Util = require('util/Util'),

--- a/src/htdocs/modules/impact/PagerPage.js
+++ b/src/htdocs/modules/impact/PagerPage.js
@@ -52,9 +52,6 @@ PagerPage.prototype.getDetailsContent = function (product) {
 
   el.classList.add('losspager');
   el.innerHTML =
-    '<small class="attribution">Data Source ' +
-      Attribution.getContributorReference(product.source) +
-      '</small>' +
     '<div class="alert-wrapper row"></div>' +
     '<div class="row pager-content">' +
       '<div class="column one-of-two">' +

--- a/src/htdocs/modules/impact/ShakeMapPage.js
+++ b/src/htdocs/modules/impact/ShakeMapPage.js
@@ -102,9 +102,7 @@ ShakeMapPage.prototype.getDetailsContent = function (product) {
   shakemap = this._shakemap = product;
 
   el.classList.add('shakemap');
-  el.innerHTML = '<small class="attribution">Data Source ' +
-      Attribution.getContributorReference(product.source) +
-      '</small><div class="shakemap-tablist"></div>';
+  el.innerHTML = '<div class="shakemap-tablist"></div>';
   tablistDiv = el.querySelector('.shakemap-tablist');
 
   if (shakemap.status.toUpperCase() === 'DELETE') {

--- a/src/htdocs/modules/impact/ShakeMapPage.js
+++ b/src/htdocs/modules/impact/ShakeMapPage.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Accordion = require('accordion/Accordion'),
-    Attribution = require('base/Attribution'),
     Formatter = require('base/Formatter'),
     ImpactUtil = require('base/ImpactUtil'),
     ProductSummarizer = require('base/ProductSummarizer'),

--- a/src/htdocs/modules/scientific/FiniteFaultPage.js
+++ b/src/htdocs/modules/scientific/FiniteFaultPage.js
@@ -2,7 +2,7 @@
 
 var Attribution = require('base/Attribution'),
     ProductSummarizer = require('base/ProductSummarizer'),
-    SummaryDetailsPage = require('base/SummaryDetailsPage'),
+    EventModulePage = require('base/EventModulePage'),
     Util = require('util/Util'),
     Xhr = require('util/Xhr');
 
@@ -12,16 +12,16 @@ var Attribution = require('base/Attribution'),
  *
  * @param options {Object}
  *        page options.
- * @see base/SummaryDetailsPage for additional options.
+ * @see base/EventModulePage for additional options.
  */
 var FiniteFaultPage = function (options) {
   options = Util.extend({}, options, {
     productType: 'finite-fault'
   });
-  SummaryDetailsPage.call(this, options);
+  EventModulePage.call(this, options);
 };
 
-FiniteFaultPage.prototype = Object.create(SummaryDetailsPage.prototype);
+FiniteFaultPage.prototype = Object.create(EventModulePage.prototype);
 
 
 /**
@@ -61,10 +61,6 @@ FiniteFaultPage.prototype.getDetailsContent = function (product) {
   }
 
   return el;
-};
-
-FiniteFaultPage.prototype._getSummaryMarkup = function (product) {
-  return ProductSummarizer.getFiniteFaultSummary(product);
 };
 
 

--- a/src/htdocs/modules/scientific/FiniteFaultPage.js
+++ b/src/htdocs/modules/scientific/FiniteFaultPage.js
@@ -1,8 +1,6 @@
 'use strict';
 
-var Attribution = require('base/Attribution'),
-    ProductSummarizer = require('base/ProductSummarizer'),
-    EventModulePage = require('base/EventModulePage'),
+var EventModulePage = require('base/EventModulePage'),
     Util = require('util/Util'),
     Xhr = require('util/Xhr');
 
@@ -48,14 +46,9 @@ FiniteFaultPage.prototype.getDetailsContent = function (product) {
     Xhr.ajax({
       url: url,
       success: function (data) {
-        // make all content urls absolute instead of relative
-        data = _this._replaceRelativePaths(data, product.contents);
-        // insert content
         el.classList.add('finite-fault');
-        el.innerHTML = '<small class="attribution">Data Source ' +
-            Attribution.getContributorReference(product.source) +
-            '</small>' +
-            data;
+        // make all content urls absolute instead of relative
+        el.innerHTML = _this._replaceRelativePaths(data, product.contents);
       }
     });
   }

--- a/src/htdocs/modules/scientific/FocalMechanismPage.js
+++ b/src/htdocs/modules/scientific/FocalMechanismPage.js
@@ -3,8 +3,7 @@
 var Attribution = require('base/Attribution'),
     Util = require('util/Util'),
 
-    MomentTensorPage = require('./MomentTensorPage'),
-    ProductSummarizer = require('base/ProductSummarizer');
+    MomentTensorPage = require('./MomentTensorPage');
 
 
 var DEFAULTS = {

--- a/src/htdocs/modules/scientific/FocalMechanismPage.js
+++ b/src/htdocs/modules/scientific/FocalMechanismPage.js
@@ -27,11 +27,6 @@ var FocalMechanismPage = function (options) {
 // extend MomentTensorPage
 FocalMechanismPage.prototype = Object.create(MomentTensorPage.prototype);
 
-
-FocalMechanismPage.prototype._getSummaryMarkup = function (product) {
-  return ProductSummarizer.getFocalMechanismSummary(product);
-};
-
 /**
  * Mechanism info.
  *

--- a/src/htdocs/modules/scientific/HypocenterPage.js
+++ b/src/htdocs/modules/scientific/HypocenterPage.js
@@ -411,17 +411,17 @@ HypocenterPage.prototype.getDetailsContent = function (product) {
   isReviewed = _isReviewed(product);
 
   el.innerHTML = [
-    _getAttribution(originAuthor, magnitudeAuthor, updateStamp),
-    '<p class="quality-statement alert ',
-        ((isPreferred && isReviewed) ? 'success' : 'warning'), '">',
-      'Currently viewing ', (isPreferred ? 'preferred' : 'non-preferred'),
-      ' data that has', (isReviewed ? ' ' : ' not '), 'been reviewed by a ',
-      'scientist.',
-    '</p>',
     '<small><a href="#scientific_summary">', ((originProducts.length === 1) ?
       'Back to Scientific Summary' :
       'View all Origins (' + originProducts.length + ' total)'),
     '</a></small>',
+    '<p class="quality-statement alert ',
+        ((isPreferred && isReviewed) ? 'success' : 'warning'), '">',
+      'The data below is', (isPreferred ? ' ' : ' NOT '),
+      'preferred.<br/>It has',
+      (isReviewed ? ' ' : ' NOT '), 'been reviewed by a scientist.',
+    '</p>',
+    _getAttribution(originAuthor, magnitudeAuthor, updateStamp)
   ].join('');
 
   // Build TabList

--- a/src/htdocs/modules/scientific/HypocenterPage.js
+++ b/src/htdocs/modules/scientific/HypocenterPage.js
@@ -257,12 +257,7 @@ HypocenterPage.prototype.getDetailsContent = function (product) {
       tabListDiv = document.createElement('section'),
       tabListContents = [],
       _this = this,
-      originDetails,
-      originAuthor,
-      originProducts,
-      magnitudeAuthor,
-      props,
-      updateStamp;
+      originDetails;
 
   formatter = new Formatter();
 
@@ -299,12 +294,6 @@ HypocenterPage.prototype.getDetailsContent = function (product) {
       }
     });
   }
-
-  props = product.properties;
-  originAuthor = props['origin-source'] || product.source;
-  magnitudeAuthor = props['magnitude-source'] || product.source;
-  updateStamp = formatter.datetime(product.updateTime, 0);
-  originProducts = this.getProducts();
 
   el.classList.add('origin');
 

--- a/src/htdocs/modules/scientific/MomentTensorPage.js
+++ b/src/htdocs/modules/scientific/MomentTensorPage.js
@@ -259,18 +259,6 @@ MomentTensorPage.prototype._getPlanes = function (tensor) {
   ].join('');
 };
 
-/**
- * Used by getSummary() method,
- * so subclasses can override non-beachball content.
- *
- * @param tensor {Tensor}
- *        tensor object.
- * @return {String} summary content.
- */
-MomentTensorPage.prototype._getSummaryMarkup = function (product) {
-  return ProductSummarizer.getMomentTensorSummary(product);
-};
-
 MomentTensorPage.prototype.getBeachball = function(tensor) {
   return new BeachBall({
       tensor: tensor,

--- a/src/htdocs/modules/scientific/MomentTensorPage.js
+++ b/src/htdocs/modules/scientific/MomentTensorPage.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Attribution = require('base/Attribution'),
-    ProductSummarizer = require('base/ProductSummarizer'),
     EventModulePage = require('base/EventModulePage'),
     Util = require('util/Util'),
 
@@ -49,9 +48,6 @@ MomentTensorPage.prototype.getDetailsContent = function (product) {
   // set layout
   el.className = 'tensor-detail';
   el.innerHTML = [
-    '<small class="attribution">Data Source ',
-      Attribution.getContributorReference(author),
-      '</small>',
     this._getTitle(tensor),
     '<div class="row clearfix">',
       '<div class="column two-of-five">',

--- a/src/htdocs/modules/scientific/MomentTensorPage.js
+++ b/src/htdocs/modules/scientific/MomentTensorPage.js
@@ -1,9 +1,8 @@
 'use strict';
 
 var Attribution = require('base/Attribution'),
-    Formatter = require('base/Formatter'),
     ProductSummarizer = require('base/ProductSummarizer'),
-    SummaryDetailsPage = require('base/SummaryDetailsPage'),
+    EventModulePage = require('base/EventModulePage'),
     Util = require('util/Util'),
 
     BeachBall = require('./tensor/BeachBall'),
@@ -11,7 +10,6 @@ var Attribution = require('base/Attribution'),
 
 // default options
 var DEFAULTS = {
-  formatter: new Formatter(),
   tabList: {
     tabPosition: 'top'
   }
@@ -26,14 +24,14 @@ var DEFAULTS = {
 var MomentTensorPage = function (options) {
   options = Util.extend({}, DEFAULTS, options);
 
-  SummaryDetailsPage.call(this, options);
+  EventModulePage.call(this, options);
 };
 
-// extend SummaryDetailsPage.
-MomentTensorPage.prototype = Object.create(SummaryDetailsPage.prototype);
+// extend EventModulePage.
+MomentTensorPage.prototype = Object.create(EventModulePage.prototype);
 
 /**
- * Called by SummaryDetailsPage._setContentMarkup(), handles
+ * Called by EventModulePage._setContentMarkup(), handles
  * displaying all detailed information for an origin product.
  *
  * @param  {object} product, origin product to display
@@ -87,7 +85,7 @@ MomentTensorPage.prototype.getDetailsContent = function (product) {
  * @return {String} markup for information.
  */
 MomentTensorPage.prototype._getInfo = function (tensor) {
-  var formatter = this._options.formatter,
+  var formatter = this._formatter,
       moment = tensor.moment,
       magnitude = tensor.magnitude,
       percentDC = tensor.percentDC,
@@ -286,7 +284,7 @@ MomentTensorPage.prototype.getBeachball = function(tensor) {
 MomentTensorPage.prototype.destroy = function () {
   this._options = null;
 
-  SummaryDetailsPage.prototype.destroy.call(this);
+  EventModulePage.prototype.destroy.call(this);
 };
 
 

--- a/src/htdocs/modules/scientific/ScientificModule.js
+++ b/src/htdocs/modules/scientific/ScientificModule.js
@@ -47,7 +47,7 @@ var DEFAULTS = {
       dependencyBundle: 'modules/scientific/index.js',
       options: {
         title: 'Moment Tensor',
-        hash: 'tensor'
+        hash: 'moment-tensor'
       },
       productTypes: ['moment-tensor']
     },
@@ -56,7 +56,7 @@ var DEFAULTS = {
       dependencyBundle: 'modules/scientific/index.js',
       options: {
         title: 'Focal Mechanism',
-        hash: 'mechanism'
+        hash: 'focal-mechanism'
       },
       productTypes: ['focal-mechanism']
     },
@@ -65,7 +65,7 @@ var DEFAULTS = {
       dependencyBundle: 'modules/scientific/index.js',
       options: {
         title: 'Finite Fault',
-        hash: 'finitefault'
+        hash: 'finite-fault'
       },
       productTypes: ['finite-fault']
     },

--- a/src/htdocs/modules/scientific/ScientificSummaryPage.js
+++ b/src/htdocs/modules/scientific/ScientificSummaryPage.js
@@ -47,8 +47,8 @@ var __getMagnitudeMarkup = function (params) {
 
 var __getNPMarkup = function (params) {
   return ['(',
-    params.formatter.fmStrike(params.plane.strike), ', ',
-    params.formatter.fmDip(params.plane.dip), ', ',
+    params.formatter.fmStrike(params.plane.strike), ',',
+    params.formatter.fmDip(params.plane.dip), ',',
     params.formatter.fmRake(params.plane.rake),
     ')'
   ].join('');
@@ -231,78 +231,6 @@ var _DEFAULTS = {
             return '<img src="' + beachBall + '" alt="Focal Mechanism"/>';
           }
         },
-        // {
-        //   label: 'NP1 - Strike',
-        //   value: function (params) {
-        //     var strike,
-        //         tensor;
-
-        //     tensor = __getTensor(params);
-        //     strike = tensor ? tensor.NP1.strike : null;
-
-        //     return params.formatter.fmStrike(strike);
-        //   }
-        // },
-        // {
-        //   label: 'NP1 - Dip',
-        //   value: function (params) {
-        //     var dip,
-        //         tensor;
-
-        //     tensor = __getTensor(params);
-        //     dip = tensor ? tensor.NP1.dip : null;
-
-        //     return params.formatter.fmDip(dip);
-        //   }
-        // },
-        // {
-        //   label: 'NP1 - Rake',
-        //   value: function (params) {
-        //     var rake,
-        //         tensor;
-
-        //     tensor = __getTensor(params);
-        //     rake = tensor ? tensor.NP1.rake : null;
-
-        //     return params.formatter.fmRake(rake);
-        //   }
-        // },
-        // {
-        //   label: 'NP2 - Strike',
-        //   value: function (params) {
-        //     var strike,
-        //         tensor;
-
-        //     tensor = __getTensor(params);
-        //     strike = tensor ? tensor.NP2.strike : null;
-
-        //     return params.formatter.fmStrike(strike);
-        //   }
-        // },
-        // {
-        //   label: 'NP2 - Dip',
-        //   value: function (params) {
-        //     var dip,
-        //         tensor;
-
-        //     tensor = __getTensor(params);
-        //     dip = tensor ? tensor.NP2.dip : null;
-
-        //     return params.formatter.fmDip(dip);
-        //   }
-        // },
-        // {
-        //   label: 'NP2 - Rake',
-        //   value: function (params) {
-        //     var rake,
-        //         tensor;
-
-        //     tensor = __getTensor(params);
-        //     rake = tensor ? tensor.NP2.rake : null;
-
-        //     return params.formatter.fmRake(rake);
-        //   }
-        // },
         {
           label: 'Nodal Plane 1<br/><small>Strike,Dip,Rake</small>',
           value: function (params) {
@@ -327,6 +255,32 @@ var _DEFAULTS = {
               formatter: params.formatter,
               plane: tensor.NP2
             });
+          }
+        },
+        {
+          label: 'Source',
+          value: __getSourceMarkup
+        }
+      ]
+    },
+    'finite-fault': {
+      display: 'Finite Fault',
+      columns: [
+        {
+          label: 'Catalog',
+          value: __getCatalogMarkup
+        },
+        {
+          label: 'Preview',
+          value: function (params) {
+            var basemap,
+                product;
+
+            product = params.product;
+            basemap = product.contents['basemap.png'];
+
+            return '<img class="image" src="' + basemap.url +
+                '" alt="Finite Fault"/>';
           }
         },
         {

--- a/src/htdocs/modules/scientific/ScientificSummaryPage.js
+++ b/src/htdocs/modules/scientific/ScientificSummaryPage.js
@@ -108,8 +108,14 @@ var _DEFAULTS = {
         {
           label: 'Time',
           value: function (params) {
-            return params.formatter.time(new Date(Date.parse(
-                params.product.properties.eventtime)));
+            var stamp;
+
+            stamp = new Date(params.product.properties.eventtime);
+
+            return '<abbr title="' +
+                params.formatter.datetime(stamp, 0) + '">' +
+              params.formatter.time(stamp, 0) +
+            '</abbr>';
           }
         },
         {

--- a/src/htdocs/modules/scientific/ScientificSummaryPage.js
+++ b/src/htdocs/modules/scientific/ScientificSummaryPage.js
@@ -18,19 +18,21 @@ var __getBeachBall = function (params) {
 var __getCatalogMarkup = function (params) {
   var markup,
       product,
-      properties;
+      properties,
+      type;
 
   product = params.product;
   properties = product.properties;
   markup = [];
+  type = product.type;
 
 
   if (params.preferred) {
-    markup.push('<abbr title="Preferred ' + params.product.type +
+    markup.push('<abbr title="Preferred ' + product.type +
         '" class="material-icons">check</abbr>');
   }
 
-  markup.push('<a href="#scientific_origin:' + product.source + '_' +
+  markup.push('<a href="#scientific_' + type + ':' + product.source + '_' +
       product.code + '">' + properties.eventsource.toUpperCase() + '</a>');
 
   return markup.join('');

--- a/src/htdocs/modules/scientific/ScientificSummaryPage.js
+++ b/src/htdocs/modules/scientific/ScientificSummaryPage.js
@@ -26,9 +26,13 @@ var __getCatalogMarkup = function (params) {
   markup = [];
   type = product.type;
 
+  if (type === 'phase-data') {
+    type = 'origin';
+  }
+
 
   if (params.preferred) {
-    markup.push('<abbr title="Preferred ' + product.type +
+    markup.push('<abbr title="Preferred ' + type +
         '" class="material-icons">check</abbr>');
   }
 

--- a/src/htdocs/modules/scientific/ScientificSummaryPage.js
+++ b/src/htdocs/modules/scientific/ScientificSummaryPage.js
@@ -300,174 +300,87 @@ var ScientificSummaryPage = function (params) {
 
 ScientificSummaryPage.prototype = Object.create(SummaryPage.prototype);
 
+
+ScientificSummaryPage.prototype._setContentMarkup = function () {
+  var additionalContent;
+
+  SummaryPage.prototype._setContentMarkup.call(this);
+
+  // Now add scitech-text and scitech-link products to this page
+  additionalContent = document.createDocumentFragment();
+
+  additionalContent.appendChild(this._getTextContents());
+  additionalContent.appendChild(this._getLinkContents());
+
+  this._content.appendChild(additionalContent);
+};
+
+
+ScientificSummaryPage.prototype._getTextContents = function () {
+  var fragment,
+      textHeader,
+      texts;
+
+  texts = this.getProducts('scitech-text');
+  fragment = document.createDocumentFragment();
+
+  if (texts.length > 0) {
+    textHeader = fragment.appendChild(document.createElement('h2'));
+    textHeader.innerHTML = 'Scientific and Technical Commentary';
+
+    texts.forEach(function (product) {
+      var container,
+          text;
+
+      if (product.contents && product.contents['']) {
+        container = fragment.appendChild(document.createElement('div'));
+        container.id = product.id;
+        container.classList.add('scitech-text');
+
+        text = product.contents[''].bytes;
+        text = this._replaceRelativePaths(text, product.contents);
+        container.innerText = text;
+      }
+    }, this);
+  }
+
+  return fragment;
+};
+
+ScientificSummaryPage.prototype._getLinkContents = function () {
+  var fragment,
+      linkHeader,
+      links,
+      list;
+
+  links = this.getProducts('scitech-link');
+  fragment = document.createDocumentFragment();
+
+  if (links.length > 0) {
+    linkHeader = fragment.appendChild(document.createElement('h2'));
+    linkHeader.innerHTML = 'Scientific and Technical Links';
+
+    list = fragment.appendChild(document.createElement('ul'));
+    list.classList.add('scitech-links');
+
+    links.forEach(function (product) {
+      var container,
+          link,
+          properties;
+
+      properties = product.properties;
+      container = list.appendChild(document.createElement('li'));
+      container.classList.add('scitech-link');
+      container.id = product.id;
+
+      link = container.appendChild(document.createElement('a'));
+      link.setAttribute('href', properties.url);
+      link.innerHTML = properties.text;
+    });
+  }
+
+  return fragment;
+};
+
+
 module.exports = ScientificSummaryPage;
-
-// 'use strict';
-
-// var EventModulePage = require('base/EventModulePage'),
-//     Formatter = require('base/Formatter'),
-//     Util = require('util/Util');
-
-
-// // default options
-// var DEFAULTS = {
-//   title: 'Summary',
-//   hash: 'summary',
-//   formatter: new Formatter()
-// };
-
-
-// /**
-//  * Create a new ScientificSummaryPage.
-//  * @param options {Object}
-//  *        module options.
-//  */
-// var ScientificSummaryPage = function (options) {
-//   this._options = Util.extend({}, DEFAULTS, options);
-//   EventModulePage.call(this, this._options);
-// };
-
-// // extend EventModulePage
-// ScientificSummaryPage.prototype = Object.create(EventModulePage.prototype);
-
-// // Do not display a header
-// ScientificSummaryPage.prototype._setHeaderMarkup = function () {};
-// // Do not display a footer
-// ScientificSummaryPage.prototype._setFooterMarkup = function () {};
-
-// /**
-//  * Render page content.
-//  */
-// ScientificSummaryPage.prototype._setContentMarkup = function () {
-//   var products = this._options.eventDetails.properties.products,
-//       product;
-
-//   // Hypocenter content
-//   if (products.hasOwnProperty('origin')) {
-//     product = products.origin[0];
-//     this.getPreferredSummaryMarkup(product, 'scientific_origin', 'Origin');
-//   }
-
-//   // Moment Tensor content
-//   if (products.hasOwnProperty('moment-tensor')) {
-//     product = products['moment-tensor'][0];
-//     this.getPreferredSummaryMarkup(product, 'scientific_tensor', 'Moment Tensor');
-//   }
-
-//   // Focal Mechanism content
-//   if (products.hasOwnProperty('focal-mechanism')) {
-//     product = products['focal-mechanism'][0];
-//     this.getPreferredSummaryMarkup(product, 'scientific_mechanism', 'Focal Mechanism');
-//   }
-
-//   // Finite Fault content
-//   if (products.hasOwnProperty('finite-fault')) {
-//     product = products['finite-fault'][0];
-//     this.getPreferredSummaryMarkup(product, 'scientific_finitefault', 'Finite Fault');
-//   }
-
-//   // scitech-text content
-//   //this.getTexts();
-//   this._content.appendChild(this.getTexts());
-
-//   // scitech-links content
-//   this._content.appendChild(this.getLinks());
-// };
-
-// /**
-//  * Get any scitech-text information.
-//  *
-//  * @return {DOMElement} content, or null if no information present.
-//  */
-// ScientificSummaryPage.prototype.getTexts = function () {
-//   var fragment = document.createDocumentFragment(),
-//       products = this._event.properties.products,
-//       texts = products['scitech-text'],
-//       textEl = null,
-//       i,
-//       len;
-
-//   if (texts) {
-//     textEl = document.createElement('div');
-//     textEl.className = 'scitech-text';
-//     textEl.innerHTML = '<h3>Scientific and Technical Commentary</h3>';
-//     fragment.appendChild(textEl);
-
-//     for (i = 0, len = texts.length; i < len; i++) {
-//       textEl.appendChild(this.getText(texts[i]));
-//     }
-//   }
-
-//   return fragment;
-// };
-
-// ScientificSummaryPage.prototype.getText = function (product) {
-//   var el = document.createElement('section'),
-//       content,
-//       contents = product.contents;
-
-//   if (contents && contents['']) {
-//     content = contents[''].bytes;
-//     content = this._replaceRelativePaths(content, product.contents);
-
-//     el.innerHTML = content;
-//   }
-
-//   return el;
-// };
-
-// /**
-//  * Get any scitech-link information.
-//  *
-//  * @return {DocumentFragment}
-//  *         Fragment with links, or empty if no information present.
-//  */
-// ScientificSummaryPage.prototype.getLinks = function () {
-//   var fragment = document.createDocumentFragment(),
-//       products = this._event.properties.products,
-//       links = products['scitech-link'],
-//       linkEl = null,
-//       i,
-//       item,
-//       len,
-//       list;
-
-//   if (links) {
-//     linkEl = document.createElement('div');
-//     linkEl.className = 'scitech-links';
-//     linkEl.innerHTML = '<h3>Scientific and Technical Links</h3>';
-//     fragment.appendChild(linkEl);
-
-//     list = document.createElement('ul');
-//     linkEl.appendChild(list);
-
-//     for (i = 0, len = links.length; i < len; i++) {
-//       item = document.createElement('li');
-//       item.appendChild(this.getLink(links[i]));
-//       list.appendChild(item);
-//     }
-//   }
-
-//   return fragment;
-// };
-
-// /**
-//  * Create an anchor element from a link product.
-//  *
-//  * @param product {Object}
-//  *        The link product.
-//  * @return {DOMEElement}
-//  *         anchor element.
-//  */
-// ScientificSummaryPage.prototype.getLink = function (product) {
-//   var el = document.createElement('a'),
-//       props = product.properties;
-
-//   el.setAttribute('href', props.url);
-//   el.innerHTML = props.text;
-
-//   return el;
-// };
-
-
-// module.exports = ScientificSummaryPage;

--- a/src/htdocs/modules/scientific/ScientificSummaryPage.js
+++ b/src/htdocs/modules/scientific/ScientificSummaryPage.js
@@ -1,169 +1,286 @@
 'use strict';
 
-var EventModulePage = require('base/EventModulePage'),
-    Formatter = require('base/Formatter'),
+var Attribution = require('base/Attribution'),
+    SummaryPage = require('base/SummaryPage'),
+
     Util = require('util/Util');
 
 
-// default options
-var DEFAULTS = {
-  title: 'Summary',
-  hash: 'summary',
-  formatter: new Formatter()
-};
+var _DEFAULTS = {
+  includeTypes: {
+    origin: {
+      display: 'Origin',
+      columns: [
+        {
+          label: 'Catalog',
+          value: function (params) {
+            var markup,
+                product,
+                properties;
+
+            product = params.product;
+            properties = product.properties;
+            markup = [];
 
 
-/**
- * Create a new ScientificSummaryPage.
- * @param options {Object}
- *        module options.
- */
-var ScientificSummaryPage = function (options) {
-  this._options = Util.extend({}, DEFAULTS, options);
-  EventModulePage.call(this, this._options);
-};
+            if (params.preferred) {
+              markup.push('<abbr title="Preferred ' + params.product.type +
+                  '" class="material-icons">check</abbr>');
+            }
 
-// extend EventModulePage
-ScientificSummaryPage.prototype = Object.create(EventModulePage.prototype);
+            markup.push('<a href="#scientific_origin:' + product.source + '_' + product.code + '">' + properties.eventsource.toUpperCase() + '</a>');
 
-// Do not display a header
-ScientificSummaryPage.prototype._setHeaderMarkup = function () {};
-// Do not display a footer
-ScientificSummaryPage.prototype._setFooterMarkup = function () {};
+            return markup.join('');
+          }
+        },
+        {
+          label: '<abbr title="Magnitude">Mag</abbr>',
+          value: function (params) {
+            var properties;
 
-/**
- * Render page content.
- */
-ScientificSummaryPage.prototype._setContentMarkup = function () {
-  var products = this._options.eventDetails.properties.products,
-      product;
+            properties = params.product.properties;
 
-  // Hypocenter content
-  if (products.hasOwnProperty('origin')) {
-    product = products.origin[0];
-    this.getPreferredSummaryMarkup(product, 'scientific_origin', 'Origin');
-  }
+            return params.formatter.magnitude(properties.magnitude,
+                properties['magnitude-type']);
+          }
+        },
+        {
+          label: 'Time',
+          value: function (params) {
+            return params.formatter.time(new Date(Date.parse(
+                params.product.properties.eventtime)));
+          }
+        },
+        {
+          label: 'Depth',
+          value: function (params) {
+            return params.formatter.depth(params.product.properties.depth);
+          }
+        },
+        {
+          label: 'Status',
+          value: function (params) {
+            return params.product.properties['review-status'].toUpperCase();
+          }
+        },
+        {
+          label: 'Location',
+          value: function (params) {
+            var properties;
 
-  // Moment Tensor content
-  if (products.hasOwnProperty('moment-tensor')) {
-    product = products['moment-tensor'][0];
-    this.getPreferredSummaryMarkup(product, 'scientific_tensor', 'Moment Tensor');
-  }
+            properties = params.product.properties;
 
-  // Focal Mechanism content
-  if (products.hasOwnProperty('focal-mechanism')) {
-    product = products['focal-mechanism'][0];
-    this.getPreferredSummaryMarkup(product, 'scientific_mechanism', 'Focal Mechanism');
-  }
+            return params.formatter.location(properties.latitude,
+                properties.longitude);
+          }
+        },
+        {
+          label: 'Source',
+          value: function (params) {
+            var magnitudeSource,
+                source,
+                originSource,
+                product,
+                properties;
 
-  // Finite Fault content
-  if (products.hasOwnProperty('finite-fault')) {
-    product = products['finite-fault'][0];
-    this.getPreferredSummaryMarkup(product, 'scientific_finitefault', 'Finite Fault');
-  }
+            product = params.product;
+            properties = product.properties;
+            source = [];
 
-  // scitech-text content
-  //this.getTexts();
-  this._content.appendChild(this.getTexts());
+            originSource = properties['origin-source'] || product.source;
+            magnitudeSource = properties['magnitude-source'] || product.source;
 
-  // scitech-links content
-  this._content.appendChild(this.getLinks());
-};
+            source.push(Attribution.getContributorReference(originSource));
 
-/**
- * Get any scitech-text information.
- *
- * @return {DOMElement} content, or null if no information present.
- */
-ScientificSummaryPage.prototype.getTexts = function () {
-  var fragment = document.createDocumentFragment(),
-      products = this._event.properties.products,
-      texts = products['scitech-text'],
-      textEl = null,
-      i,
-      len;
+            if (originSource !== magnitudeSource) {
+              source.push(Attribution.getContributorReference(magnitudeSource));
+            }
 
-  if (texts) {
-    textEl = document.createElement('div');
-    textEl.className = 'scitech-text';
-    textEl.innerHTML = '<h3>Scientific and Technical Commentary</h3>';
-    fragment.appendChild(textEl);
-
-    for (i = 0, len = texts.length; i < len; i++) {
-      textEl.appendChild(this.getText(texts[i]));
+            return source.join('');
+          }
+        }
+        // source
+      ]
     }
   }
-
-  return fragment;
 };
 
-ScientificSummaryPage.prototype.getText = function (product) {
-  var el = document.createElement('section'),
-      content,
-      contents = product.contents;
+var ScientificSummaryPage = function (params) {
+  this._options = Util.extend({}, _DEFAULTS, params);
 
-  if (contents && contents['']) {
-    content = contents[''].bytes;
-    content = this._replaceRelativePaths(content, product.contents);
-
-    el.innerHTML = content;
-  }
-
-  return el;
+  SummaryPage.call(this, this._options);
 };
 
-/**
- * Get any scitech-link information.
- *
- * @return {DocumentFragment}
- *         Fragment with links, or empty if no information present.
- */
-ScientificSummaryPage.prototype.getLinks = function () {
-  var fragment = document.createDocumentFragment(),
-      products = this._event.properties.products,
-      links = products['scitech-link'],
-      linkEl = null,
-      i,
-      item,
-      len,
-      list;
-
-  if (links) {
-    linkEl = document.createElement('div');
-    linkEl.className = 'scitech-links';
-    linkEl.innerHTML = '<h3>Scientific and Technical Links</h3>';
-    fragment.appendChild(linkEl);
-
-    list = document.createElement('ul');
-    linkEl.appendChild(list);
-
-    for (i = 0, len = links.length; i < len; i++) {
-      item = document.createElement('li');
-      item.appendChild(this.getLink(links[i]));
-      list.appendChild(item);
-    }
-  }
-
-  return fragment;
-};
-
-/**
- * Create an anchor element from a link product.
- *
- * @param product {Object}
- *        The link product.
- * @return {DOMEElement}
- *         anchor element.
- */
-ScientificSummaryPage.prototype.getLink = function (product) {
-  var el = document.createElement('a'),
-      props = product.properties;
-
-  el.setAttribute('href', props.url);
-  el.innerHTML = props.text;
-
-  return el;
-};
-
+ScientificSummaryPage.prototype = Object.create(SummaryPage.prototype);
 
 module.exports = ScientificSummaryPage;
+
+// 'use strict';
+
+// var EventModulePage = require('base/EventModulePage'),
+//     Formatter = require('base/Formatter'),
+//     Util = require('util/Util');
+
+
+// // default options
+// var DEFAULTS = {
+//   title: 'Summary',
+//   hash: 'summary',
+//   formatter: new Formatter()
+// };
+
+
+// /**
+//  * Create a new ScientificSummaryPage.
+//  * @param options {Object}
+//  *        module options.
+//  */
+// var ScientificSummaryPage = function (options) {
+//   this._options = Util.extend({}, DEFAULTS, options);
+//   EventModulePage.call(this, this._options);
+// };
+
+// // extend EventModulePage
+// ScientificSummaryPage.prototype = Object.create(EventModulePage.prototype);
+
+// // Do not display a header
+// ScientificSummaryPage.prototype._setHeaderMarkup = function () {};
+// // Do not display a footer
+// ScientificSummaryPage.prototype._setFooterMarkup = function () {};
+
+// /**
+//  * Render page content.
+//  */
+// ScientificSummaryPage.prototype._setContentMarkup = function () {
+//   var products = this._options.eventDetails.properties.products,
+//       product;
+
+//   // Hypocenter content
+//   if (products.hasOwnProperty('origin')) {
+//     product = products.origin[0];
+//     this.getPreferredSummaryMarkup(product, 'scientific_origin', 'Origin');
+//   }
+
+//   // Moment Tensor content
+//   if (products.hasOwnProperty('moment-tensor')) {
+//     product = products['moment-tensor'][0];
+//     this.getPreferredSummaryMarkup(product, 'scientific_tensor', 'Moment Tensor');
+//   }
+
+//   // Focal Mechanism content
+//   if (products.hasOwnProperty('focal-mechanism')) {
+//     product = products['focal-mechanism'][0];
+//     this.getPreferredSummaryMarkup(product, 'scientific_mechanism', 'Focal Mechanism');
+//   }
+
+//   // Finite Fault content
+//   if (products.hasOwnProperty('finite-fault')) {
+//     product = products['finite-fault'][0];
+//     this.getPreferredSummaryMarkup(product, 'scientific_finitefault', 'Finite Fault');
+//   }
+
+//   // scitech-text content
+//   //this.getTexts();
+//   this._content.appendChild(this.getTexts());
+
+//   // scitech-links content
+//   this._content.appendChild(this.getLinks());
+// };
+
+// /**
+//  * Get any scitech-text information.
+//  *
+//  * @return {DOMElement} content, or null if no information present.
+//  */
+// ScientificSummaryPage.prototype.getTexts = function () {
+//   var fragment = document.createDocumentFragment(),
+//       products = this._event.properties.products,
+//       texts = products['scitech-text'],
+//       textEl = null,
+//       i,
+//       len;
+
+//   if (texts) {
+//     textEl = document.createElement('div');
+//     textEl.className = 'scitech-text';
+//     textEl.innerHTML = '<h3>Scientific and Technical Commentary</h3>';
+//     fragment.appendChild(textEl);
+
+//     for (i = 0, len = texts.length; i < len; i++) {
+//       textEl.appendChild(this.getText(texts[i]));
+//     }
+//   }
+
+//   return fragment;
+// };
+
+// ScientificSummaryPage.prototype.getText = function (product) {
+//   var el = document.createElement('section'),
+//       content,
+//       contents = product.contents;
+
+//   if (contents && contents['']) {
+//     content = contents[''].bytes;
+//     content = this._replaceRelativePaths(content, product.contents);
+
+//     el.innerHTML = content;
+//   }
+
+//   return el;
+// };
+
+// /**
+//  * Get any scitech-link information.
+//  *
+//  * @return {DocumentFragment}
+//  *         Fragment with links, or empty if no information present.
+//  */
+// ScientificSummaryPage.prototype.getLinks = function () {
+//   var fragment = document.createDocumentFragment(),
+//       products = this._event.properties.products,
+//       links = products['scitech-link'],
+//       linkEl = null,
+//       i,
+//       item,
+//       len,
+//       list;
+
+//   if (links) {
+//     linkEl = document.createElement('div');
+//     linkEl.className = 'scitech-links';
+//     linkEl.innerHTML = '<h3>Scientific and Technical Links</h3>';
+//     fragment.appendChild(linkEl);
+
+//     list = document.createElement('ul');
+//     linkEl.appendChild(list);
+
+//     for (i = 0, len = links.length; i < len; i++) {
+//       item = document.createElement('li');
+//       item.appendChild(this.getLink(links[i]));
+//       list.appendChild(item);
+//     }
+//   }
+
+//   return fragment;
+// };
+
+// /**
+//  * Create an anchor element from a link product.
+//  *
+//  * @param product {Object}
+//  *        The link product.
+//  * @return {DOMEElement}
+//  *         anchor element.
+//  */
+// ScientificSummaryPage.prototype.getLink = function (product) {
+//   var el = document.createElement('a'),
+//       props = product.properties;
+
+//   el.setAttribute('href', props.url);
+//   el.innerHTML = props.text;
+
+//   return el;
+// };
+
+
+// module.exports = ScientificSummaryPage;

--- a/src/htdocs/modules/scientific/ScientificSummaryPage.js
+++ b/src/htdocs/modules/scientific/ScientificSummaryPage.js
@@ -45,6 +45,15 @@ var __getMagnitudeMarkup = function (params) {
       properties['magnitude-type']);
 };
 
+var __getNPMarkup = function (params) {
+  return ['(',
+    params.formatter.fmStrike(params.plane.strike), ', ',
+    params.formatter.fmDip(params.plane.dip), ', ',
+    params.formatter.fmRake(params.plane.rake),
+    ')'
+  ].join('');
+};
+
 var __getSourceMarkup = function (params) {
   var magnitudeSource,
       source,
@@ -66,6 +75,14 @@ var __getSourceMarkup = function (params) {
   }
 
   return source.join('');
+};
+
+var __getTensor = function (params) {
+  if (!params.tensor) {
+    params.tensor = Tensor.fromProduct(params.product);
+  }
+
+  return params.tensor;
 };
 
 
@@ -133,8 +150,7 @@ var _DEFAULTS = {
                 tensor;
 
             product = params.product;
-            params.tensor = params.tensor || Tensor.fromProduct(product);
-            tensor = params.tensor;
+            tensor = __getTensor(params);
 
             beachBall = __getBeachBall({
               tensor: tensor,
@@ -153,8 +169,7 @@ var _DEFAULTS = {
           value: function (params) {
             var tensor;
 
-            params.tensor = params.tensor || Tensor.fromProduct(params.product);
-            tensor = params.tensor;
+            tensor = __getTensor(params);
 
             if (tensor) {
               return params.formatter.magnitude(
@@ -169,8 +184,7 @@ var _DEFAULTS = {
           value: function (params) {
             var tensor;
 
-            params.tensor = params.tensor || Tensor.fromProduct(params.product);
-            tensor = params.tensor;
+            tensor = __getTensor(params);
 
             return params.formatter.depth(tensor ? tensor.depth : null);
           }
@@ -180,14 +194,139 @@ var _DEFAULTS = {
           value: function (params) {
             var tensor;
 
-            params.tensor = params.tensor || Tensor.fromProduct(params.product);
-            tensor = params.tensor;
+            tensor = __getTensor(params);
 
             if (tensor) {
               return Math.round(tensor.percentDC * 100) + ' %';
             } else {
               return '&ndash;';
             }
+          }
+        },
+        {
+          label: 'Source',
+          value: __getSourceMarkup
+        }
+      ]
+    },
+    'focal-mechanism': {
+      display: 'Focal Mechanism',
+      columns: [
+        {
+          label: 'Catalog',
+          value: __getCatalogMarkup
+        },
+        {
+          label: 'Mechanism',
+          value: function (params) {
+            var beachBall,
+                tensor;
+
+            tensor = __getTensor(params);
+            beachBall = __getBeachBall({
+              tensor: tensor,
+              fillColor: tensor.fillColor
+            });
+
+            return '<img src="' + beachBall + '" alt="Focal Mechanism"/>';
+          }
+        },
+        // {
+        //   label: 'NP1 - Strike',
+        //   value: function (params) {
+        //     var strike,
+        //         tensor;
+
+        //     tensor = __getTensor(params);
+        //     strike = tensor ? tensor.NP1.strike : null;
+
+        //     return params.formatter.fmStrike(strike);
+        //   }
+        // },
+        // {
+        //   label: 'NP1 - Dip',
+        //   value: function (params) {
+        //     var dip,
+        //         tensor;
+
+        //     tensor = __getTensor(params);
+        //     dip = tensor ? tensor.NP1.dip : null;
+
+        //     return params.formatter.fmDip(dip);
+        //   }
+        // },
+        // {
+        //   label: 'NP1 - Rake',
+        //   value: function (params) {
+        //     var rake,
+        //         tensor;
+
+        //     tensor = __getTensor(params);
+        //     rake = tensor ? tensor.NP1.rake : null;
+
+        //     return params.formatter.fmRake(rake);
+        //   }
+        // },
+        // {
+        //   label: 'NP2 - Strike',
+        //   value: function (params) {
+        //     var strike,
+        //         tensor;
+
+        //     tensor = __getTensor(params);
+        //     strike = tensor ? tensor.NP2.strike : null;
+
+        //     return params.formatter.fmStrike(strike);
+        //   }
+        // },
+        // {
+        //   label: 'NP2 - Dip',
+        //   value: function (params) {
+        //     var dip,
+        //         tensor;
+
+        //     tensor = __getTensor(params);
+        //     dip = tensor ? tensor.NP2.dip : null;
+
+        //     return params.formatter.fmDip(dip);
+        //   }
+        // },
+        // {
+        //   label: 'NP2 - Rake',
+        //   value: function (params) {
+        //     var rake,
+        //         tensor;
+
+        //     tensor = __getTensor(params);
+        //     rake = tensor ? tensor.NP2.rake : null;
+
+        //     return params.formatter.fmRake(rake);
+        //   }
+        // },
+        {
+          label: 'Nodal Plane 1<br/><small>Strike,Dip,Rake</small>',
+          value: function (params) {
+            var tensor;
+
+            tensor = __getTensor(params);
+
+            return __getNPMarkup({
+              formatter: params.formatter,
+              plane: tensor.NP1
+            });
+          }
+        },
+        {
+          label: 'Nodal Plane 2<br/><small>Strike,Dip,Rake</small>',
+          value: function (params) {
+            var tensor;
+
+            tensor = __getTensor(params);
+
+            return __getNPMarkup({
+              formatter: params.formatter,
+              plane: tensor.NP2
+            });
           }
         },
         {

--- a/src/htdocs/modules/scientific/_HypocenterPage.scss
+++ b/src/htdocs/modules/scientific/_HypocenterPage.scss
@@ -1,12 +1,3 @@
-
-.origin-summary > ul > li {
-  width: 25%;
-
-  @media screen and (min-width: 560px) {
-    width: 20%;
-  }
-}
-
 .origin-detail {
   max-width: 750px;
   width: 100%;

--- a/src/htdocs/modules/summary/ExecutiveSummaryPage.js
+++ b/src/htdocs/modules/summary/ExecutiveSummaryPage.js
@@ -135,6 +135,9 @@ var ExecutiveSummaryPage = function (params) {
     content.innerHTML = contentMarkup.join('');
   };
 
+  _this.setDownloadMarkup = function () {
+  };
+
 
   // ------------------------------
   // Compatibility wedges ...

--- a/test/spec/modules/base/EventUtilTest.js
+++ b/test/spec/modules/base/EventUtilTest.js
@@ -1,0 +1,99 @@
+/* global after, before, chai, describe, it */
+'use strict';
+
+
+var EventUtil = require('base/EventUtil');
+
+
+var expect;
+
+expect = chai.expect;
+
+
+describe('EventUtil', function () {
+  describe('Basic Structure', function () {
+    it('conforms to the API', function () {
+      expect(EventUtil).to.respondTo('getAttribution');
+      expect(EventUtil).to.respondTo('getCodeFromHash');
+      expect(EventUtil).to.respondTo('getProducts');
+    });
+  });
+
+  describe('getAttribution()', function () {
+    it('returns an empty string when no product is given', function () {
+      expect(EventUtil.getAttribution()).to.equal('');
+    });
+
+    it('returns an attribution string when a product is given', function () {
+      var div,
+          product;
+
+      product = {
+        source: 'us',
+        updateTime: (new Date(0)).getTime()
+      };
+
+      div = document.createElement('div');
+      div.innerHTML = EventUtil.getAttribution(product);
+
+      /* jshint -W030 */
+      expect(div.querySelector('.attribution')).to.not.be.null;
+      /* jshint +W030 */
+    });
+  });
+
+  describe('getCodeFromHash()', function () {
+    var originalHash,
+        testCode,
+        testHash;
+
+    before(function () {
+      testCode = 'us_usabcd1234';
+      testHash = '#scientific_origin:' + testCode;
+      originalHash = window.location.hash;
+
+      window.location.hash = testHash;
+    });
+
+    after(function () {
+      window.location.hash = originalHash;
+    });
+
+    it('returns the expected code info', function () {
+      expect(EventUtil.getCodeFromHash()).to.equal(testCode);
+    });
+  });
+
+  describe('getProducts', function () {
+    it('returns an empty array when no products are found', function () {
+      var products;
+
+      products = EventUtil.getProducts({
+        properties: {
+          products: {}
+        }
+      }, 'faketype');
+
+      try {
+        expect(products.length).to.equal(0);
+      } catch (e) {
+        expect('Exception thrown: ' + e.message).to.equal('');
+      }
+    });
+
+    it('returns a list of products', function () {
+      var products;
+
+      products = EventUtil.getProducts({
+        properties: {
+          products: {
+            sometype: [{}, {}],
+            anothertype: [{}, {}, {}, {}]
+          }
+        }
+      }, 'sometype');
+
+      expect(products.length).to.equal(2);
+    });
+  });
+});

--- a/test/spec/modules/impact/ShakeMapPageTest.js
+++ b/test/spec/modules/impact/ShakeMapPageTest.js
@@ -17,6 +17,7 @@ var eventDetails = {
         source: 'us',
         code: 'usc000myqq',
         status: 'UPDATE',
+        properties: {},
         contents: {
           'download/intensity.jpg': {url: 'intensity.jpg'},
           'download/pga.jpg': {url: 'pga.jpg'},
@@ -83,6 +84,7 @@ describe('ShakeMapPageTest test suite.', function () {
             source: 'US',
             code: 'us10001ldx',
             status: 'UPDATE',
+            properties: {},
             contents: {
               'download/stationlist.json': {
                 url:'stationlist.json'

--- a/test/spec/modules/scientific/HypocenterPageTest.js
+++ b/test/spec/modules/scientific/HypocenterPageTest.js
@@ -1,18 +1,18 @@
 /* global chai, sinon, describe, it, beforeEach, afterEach, before */
 'use strict';
 
-var expect = chai.expect,
-    HypocenterPage = require('scientific/HypocenterPage'),
-    ScientificModule = require('scientific/ScientificModule'),
+var HypocenterPage = require('scientific/HypocenterPage'),
     Quakeml = require('quakeml/Quakeml'),
+    ScientificModule = require('scientific/ScientificModule'),
     Util = require('util/Util'),
     Xhr = require('util/Xhr'),
 
-    eventDetails = require('./usb000kqnc'),
-    summaryOptions,
+    eventDetails = require('./usb000kqnc');
+
+var basicOptions,
     detailOptions,
-    SummaryPage,
-    DetailPage;
+    detailPage,
+    expect;
 
 
 var _fireClickEvent = function (target) {
@@ -21,8 +21,9 @@ var _fireClickEvent = function (target) {
   target.dispatchEvent(clickEvent);
 };
 
+expect = chai.expect;
 
-summaryOptions = {
+basicOptions = {
   eventDetails: eventDetails,
   module: new ScientificModule(),
   // source: 'us',
@@ -33,17 +34,16 @@ summaryOptions = {
   title: 'Origin',
   hash: 'origin'
 };
-SummaryPage = new HypocenterPage(summaryOptions);
 
-detailOptions = Util.extend({}, summaryOptions, {code: 'us_usb000kqnc'});
-DetailPage = new HypocenterPage(detailOptions);
+detailOptions = Util.extend({}, basicOptions, {code: 'us_usb000kqnc'});
+detailPage = new HypocenterPage(detailOptions);
 
 before( function (done) {
   Xhr.ajax({
     url: '/spec/modules/scientific/usc000njrq_phase-data.xml',
     success: function (xml) {
       // use quakeml parser to make xml into quakeml
-      DetailPage._quakeml = new Quakeml({xml: xml});
+      detailPage._quakeml = new Quakeml({xml: xml});
       done();
     },
     error: function () {
@@ -62,71 +62,29 @@ describe('HypocenterPage test suite.', function () {
     });
 
     it('Can be instantiated', function () {
-      expect(SummaryPage).to.be.an.instanceof(HypocenterPage);
+      expect(detailPage).to.be.an.instanceof(HypocenterPage);
     });
   });
 
   describe('getContent()', function () {
-    it('Can get summary information.', function () {
-      var content = SummaryPage.getContent();
-      expect(typeof content).to.equal('object');
-    });
-
-    // _getInfo()
-    it('Can summarize hypocenter data.', function () {
-      var content = SummaryPage.getContent();
-      var hypocenter_summary =
-          content.querySelectorAll('.origin-summary');
-      /* jshint -W030 */
-      expect(hypocenter_summary.length).to.not.equal(0);
-      /* jshint +W030 */
-    });
-
     it('Loads phases when tab is clicked.', function () {
       // The phase element should be empty
-      expect(DetailPage._phaseEl.innerHTML).to.equal('');
+      expect(detailPage._phaseEl.innerHTML).to.equal('');
       // select phase tab
       _fireClickEvent(
-          DetailPage._content.querySelector('nav :nth-child(2)'));
-      expect(DetailPage._phaseEl.innerHTML).to.not.equal('');
+          detailPage._content.querySelector('nav :nth-child(2)'));
+      expect(detailPage._phaseEl.innerHTML).to.not.equal('');
     });
 
     it('Loads magnitudes when tab is clicked.', function () {
       // The magnitude element should be empty
-      expect(DetailPage._magnitudeEl.innerHTML).to.equal('');
+      expect(detailPage._magnitudeEl.innerHTML).to.equal('');
       // select magnitude tab
       _fireClickEvent(
-          DetailPage._content.querySelector('nav :nth-child(3)'));
+          detailPage._content.querySelector('nav :nth-child(3)'));
       // The phase element should not be empty anymore
-      expect(DetailPage._magnitudeEl.innerHTML).to.not.equal('');
+      expect(detailPage._magnitudeEl.innerHTML).to.not.equal('');
     });
-
-    it('Can be awesome.', function () {
-      var content = null;
-      // Just because it can be.
-      content = 'Awesome!';
-      expect(content).to.equal('Awesome!');
-    });
-
-    // TODO :: Re-enable after CORS is configured
-    it.skip('Toggles magnitude details.', function () {
-      var magEl,
-          linkEl;
-
-      DetailPage._tabList._tabs[2].select();
-      magEl = DetailPage._tabList.el.querySelector('.networkmagnitude');
-      linkEl = magEl.querySelector('.expand');
-
-      expect(magEl.classList.contains('show-networkmagnitude-details')).
-          to.equal(false);
-      DetailPage._toggleMagnitudeDetails({target: linkEl});
-      expect(magEl.classList.contains('show-networkmagnitude-details')).
-          to.equal(true);
-      DetailPage._toggleMagnitudeDetails({target: linkEl});
-      expect(magEl.classList.contains('show-networkmagnitude-details')).
-          to.equal(false);
-    });
-
   });
 
   describe('getFeString', function () {
@@ -135,7 +93,7 @@ describe('HypocenterPage test suite.', function () {
         ajaxStub = null;
 
     beforeEach(function () {
-      hp = new HypocenterPage(summaryOptions);
+      hp = new HypocenterPage(basicOptions);
 
       product = hp.getProducts()[0];
 

--- a/test/spec/modules/scientific/MomentTensorTest.js
+++ b/test/spec/modules/scientific/MomentTensorTest.js
@@ -39,23 +39,6 @@ describe('MomentTensorSummary test suite.', function () {
     });
   });
 
-  describe('getSummaryContent', function () {
-
-    it('Can get summary information.', function () {
-      var content = page.getContent();
-      expect(typeof content).to.equal('object');
-    });
-
-    // _getInfo()
-    it('Can summarize moment tensor data.', function () {
-      var content = page.getContent();
-      var tensor_summary = content.querySelectorAll('.tensor-summary');
-      /* jshint -W030 */
-      expect(tensor_summary.length).to.not.equal(0);
-      /* jshint +W030 */
-    });
-  });
-
   describe('getDetailContent()', function () {
 
     var expect = chai.expect,

--- a/test/spec/modules/scientific/ScientificSummaryPageTest.js
+++ b/test/spec/modules/scientific/ScientificSummaryPageTest.js
@@ -40,7 +40,7 @@ describe('Scientific Summary Page', function () {
       var el = page._content.querySelector('.scitech-text');
 
       expect(el).to.not.equal(null);
-      expect(el.querySelector('section').innerHTML).to.equal(
+      expect(el.innerHTML).to.equal(
           nc72119972.properties.products['scitech-text'][0].contents[''].bytes);
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,7 @@ mocha.setup('bdd');
 require('./spec/modules/base/EventPageTest');
 require('./spec/modules/base/EventModuleTest');
 require('./spec/modules/base/EventModulePageTest');
+require('./spec/modules/base/EventUtilTest');
 require('./spec/modules/summary/SummaryPageTest');
 require('./spec/modules/summary/InteractiveMapTest');
 require('./spec/modules/impact/ImpactModuleTest');


### PR DESCRIPTION
fixes usgs/earthquake-eventpages#219

Quite a deviation from the original issue. Summaries are now found on the module summary page only. These summaries to include location and time information for origin products as desired. Navigation links go directly to preferred information.

This change might also address (or make irrelevant) the following issues:
- #254
- #247

