### PR TITLE
Remove Node.innerText from use on eventpages

### DIFF
--- a/src/htdocs/modules/scientific/ScientificSummaryPage.js
+++ b/src/htdocs/modules/scientific/ScientificSummaryPage.js
@@ -351,7 +351,7 @@ ScientificSummaryPage.prototype._getTextContents = function () {
 
         text = product.contents[''].bytes;
         text = this._replaceRelativePaths(text, product.contents);
-        container.innerText = text;
+        container.innerHTML = text;
       }
     }, this);
   }

--- a/src/htdocs/modules/summary/ExecutiveSummaryPage.js
+++ b/src/htdocs/modules/summary/ExecutiveSummaryPage.js
@@ -43,7 +43,6 @@ var ExecutiveSummaryPage = function (params) {
   _getImpactTextMarkup = function (product) {
     var classes,
         content,
-        el,
         markup,
         properties;
 
@@ -58,12 +57,9 @@ var ExecutiveSummaryPage = function (params) {
     }
 
     if (content.hasOwnProperty('')) {
-      el = document.createElement('div');
-      el.innerText = content[''].bytes;
-
       markup = [
         '<p class="', classes.join(' '), '">',
-          el.innerHTML,
+          content[''].bytes,
         '</p>'
       ];
     }


### PR DESCRIPTION
fixes #284 

Node.innerText is a non-standard property