### PR TITLE
Add destroy to EventPage, CatalogEvent; implement and test EventPage.…

### DIFF
--- a/src/htdocs/js/core/EventPage.js
+++ b/src/htdocs/js/core/EventPage.js
@@ -193,7 +193,7 @@ var EventPage = function (options) {
   /**
    * Unbind event listeners and free references.
    */
-  _this.destroy = function () {
+  _this.destroy = Util.compose(function () {
     if (!_this) {
       return;
     }
@@ -232,7 +232,7 @@ var EventPage = function (options) {
     _modules = null;
     _navEl = null;
     _this = null;
-  };
+  }, _this.destroy);
 
 
   /**

--- a/src/htdocs/js/pdl/CatalogEvent.js
+++ b/src/htdocs/js/pdl/CatalogEvent.js
@@ -292,6 +292,29 @@ var CatalogEvent = function (eventDetails) {
   };
 
   /**
+   * Free references.
+   */
+  _this.destroy = function () {
+    var key;
+
+    if (_this === null) {
+      return;
+    }
+
+    for (key in _products) {
+      _products[key].map(function (model) {
+        model.destroy();
+      });
+    }
+
+    _initialize = null;
+    _products = null;
+    _properties = null;
+    _summary = null;
+    _this = null;
+  };
+
+  /**
    * Get event products.
    */
   _this.getProducts = function (type) {

--- a/test/spec/core/EventPageTest.js
+++ b/test/spec/core/EventPageTest.js
@@ -1,7 +1,10 @@
-/* global chai, describe, it, sinon */
+/* global after, before, chai, describe, it, sinon */
 'use strict';
 
-var EventPage = require('core/EventPage');
+var CatalogEvent = require('pdl/CatalogEvent'),
+    EventPage = require('core/EventPage'),
+    Events = require('util/Events'),
+    Xhr = require('util/Xhr');
 
 var expect = chai.expect;
 
@@ -23,6 +26,7 @@ describe('core/EventPage', function () {
         }
       });
       expect(eventPage.isScenarioMode()).to.equal(true);
+      eventPage.destroy();
     });
 
     it('returns false otherwise', function () {
@@ -30,6 +34,7 @@ describe('core/EventPage', function () {
       eventPage = EventPage();
 
       expect(eventPage.isScenarioMode()).to.equal(false);
+      eventPage.destroy();
     });
   });
 
@@ -45,6 +50,7 @@ describe('core/EventPage', function () {
       };
       eventPage.moduleHasContent(module);
       expect(module.hasContent.calledOnce).to.equal(true);
+      eventPage.destroy();
     });
 
     it('checks module TYPES array', function () {
@@ -59,6 +65,7 @@ describe('core/EventPage', function () {
       expect(eventPage.moduleHasContent(module, ['abc'])).to.equal(true);
       expect(eventPage.moduleHasContent(module, ['def'])).to.equal(true);
       expect(eventPage.moduleHasContent(module, ['abc-scenario'])).to.equal(false);
+      eventPage.destroy();
     });
 
     it('adds scenario suffix when event is in scenario mode', function () {
@@ -77,6 +84,56 @@ describe('core/EventPage', function () {
       expect(eventPage.moduleHasContent(module, ['abc-scenario'])).to.equal(true);
       expect(eventPage.moduleHasContent(module, ['def-scenario'])).to.equal(true);
       expect(eventPage.moduleHasContent(module, ['abc'])).to.equal(false);
+      eventPage.destroy();
+    });
+  });
+
+  describe('onBack', function () {
+    var ev;
+
+    before(function (done) {
+      Xhr.ajax({
+        url: '/events/us10004u1y.json',
+        success: function (data) {
+          ev = CatalogEvent(data);
+          done();
+        },
+        error: function () {
+          done(false);
+        }
+      });
+    });
+
+    after(function () {
+      ev.destroy();
+      ev = null;
+      window.location.hash = '';
+    });
+
+    it('is called when "back" event triggered', function () {
+      var eventPage;
+
+      eventPage = EventPage();
+      sinon.stub(eventPage, 'onBack', function () {});
+      Events.trigger('back');
+      expect(eventPage.onBack.calledOnce).to.equal(true);
+      eventPage.onBack.restore();
+      eventPage.destroy();
+    });
+
+    it('loads default module when not hasPrevious', function () {
+      var eventPage;
+
+      // start event page on moment tensor module
+      window.location.hash = '#moment-tensor';
+      eventPage = EventPage({
+        'event': ev
+      });
+      expect(window.location.hash).to.equal('#moment-tensor');
+      // has previous should not be true yet
+      Events.trigger('back');
+      expect(window.location.hash).to.equal('#general');
+      eventPage.destroy();
     });
   });
 


### PR DESCRIPTION
…onBack

Fixes #368 

Open to suggestions for automated testing onBack when it calls window.history.back().  For now, manual test:

1) load default when not hasPrevious
- Open new tab, navigate directly to interactive map
http://localhost:8100/earthquakes/eventpage/us10004u1y#map
- Click close button
- Expect general summary module

2) window.history.back when hasPrevious
- Open new tab, navigation directly to finite fault module
http://localhost:8100/earthquakes/eventpage/us10004u1y#finite-fault
- Open interactive map using nav
- Click close button
- Expect finite fault module