### PR TITLE
General module 3

### DIFF
--- a/src/htdocs/js/core/ContentView.js
+++ b/src/htdocs/js/core/ContentView.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var View = require('mvc/View'),
+var Util = require('util/Util'),
+    View = require('mvc/View'),
     Xhr = require('util/Xhr');
 
 
@@ -11,11 +12,19 @@ var View = require('mvc/View'),
  *     all options are passed to mvc/View.
  */
 var ContentView = function (options) {
-  var _this;
+  var _this,
+
+      _xhr;
 
   _this = View(options);
 
-  // TODO: render summary information
+  _this.destroy = Util.compose(function () {
+    if (_xhr) {
+      _xhr.abort();
+      _xhr = null;
+    }
+    _this = null;
+  }, _this.destroy);
 
   /**
    * Asynchronous method to fetch the data associated with _this.model {Content}
@@ -30,12 +39,21 @@ var ContentView = function (options) {
     data = _this.model.get('bytes');
     if (data !== null) {
       // force async
-      setTimeout(function () { _this.onSuccess(data, null); }, 0);
+      setTimeout(function () {
+        if (_this) {
+          _this.onSuccess(data, null);
+        } else {
+          console.log(data);
+        }
+      }, 0);
     } else {
-      Xhr.ajax({
+      _xhr = Xhr.ajax({
         url: _this.model.get('url'),
         success: _this.onSuccess,
-        error: _this.onError
+        error: _this.onError,
+        done: function () {
+          _xhr = null;
+        }
       });
     }
   };

--- a/src/htdocs/js/core/ContentView.js
+++ b/src/htdocs/js/core/ContentView.js
@@ -42,7 +42,7 @@ var ContentView = function (options) {
       setTimeout(function () {
         if (!_this) {
           // view was destroyed before next tick
-          // simluate async abort
+          // simulate async abort
           return;
         }
         _this.onSuccess(data, null);

--- a/src/htdocs/js/core/ContentView.js
+++ b/src/htdocs/js/core/ContentView.js
@@ -40,11 +40,12 @@ var ContentView = function (options) {
     if (data !== null) {
       // force async
       setTimeout(function () {
-        if (_this) {
-          _this.onSuccess(data, null);
-        } else {
-          console.log(data);
+        if (!_this) {
+          // view was destroyed before next tick
+          // simluate async abort
+          return;
         }
+        _this.onSuccess(data, null);
       }, 0);
     } else {
       _xhr = Xhr.ajax({

--- a/src/htdocs/js/general/GeoserveNearbyPlacesView.js
+++ b/src/htdocs/js/general/GeoserveNearbyPlacesView.js
@@ -22,7 +22,8 @@ var GeoserveNearbyPlacesView = function (options) {
       _initialize,
 
       _formatter,
-      _url;
+      _url,
+      _xhr;
 
 
   options = Util.extend({}, _DEFAULTS, options);
@@ -45,7 +46,7 @@ var GeoserveNearbyPlacesView = function (options) {
    * Gets data
    */
   _this.fetchData = function () {
-    Xhr.ajax({
+    _xhr = Xhr.ajax({
       url: _url,
       success: _this.onSuccess,
       error: _this.onError,
@@ -53,6 +54,9 @@ var GeoserveNearbyPlacesView = function (options) {
         latitude: _this.model.getProperty('latitude'),
         longitude: _this.model.getProperty('longitude'),
         type: 'event'
+      },
+      done: function () {
+        _xhr = null;
       }
     });
   };
@@ -109,6 +113,10 @@ var GeoserveNearbyPlacesView = function (options) {
    * Destroy all the things.
    */
   _this.destroy = Util.compose(function () {
+    if (_xhr) {
+      _xhr.abort();
+      _xhr = null;
+    }
     _url = null;
     _formatter = null;
     _initialize = null;

--- a/src/htdocs/js/general/GeoserveRegionSummaryView.js
+++ b/src/htdocs/js/general/GeoserveRegionSummaryView.js
@@ -20,7 +20,8 @@ var GeoserveRegionSummaryView = function (options) {
   var _this,
       _initialize,
 
-      _url;
+      _url,
+      _xhr;
 
 
   options = Util.extend({}, _DEFAULTS, options);
@@ -36,7 +37,7 @@ var GeoserveRegionSummaryView = function (options) {
    * Gets data
    */
   _this.fetchData = function () {
-    Xhr.ajax({
+    _xhr = Xhr.ajax({
       url: _url,
       success: _this.onSuccess,
       error: _this.onError,
@@ -44,6 +45,9 @@ var GeoserveRegionSummaryView = function (options) {
         latitude: _this.model.getProperty('latitude'),
         longitude: _this.model.getProperty('longitude'),
         type: 'tectonic'
+      },
+      done: function () {
+        _xhr = null;
       }
     });
   };
@@ -91,6 +95,10 @@ var GeoserveRegionSummaryView = function (options) {
    * Destroy all the things.
    */
   _this.destroy = Util.compose(function () {
+    if (_xhr) {
+      _xhr.abort();
+      _xhr = null;
+    }
     _url = null;
     _initialize = null;
     _this = null;

--- a/src/htdocs/js/general/NearbyPlacesView.js
+++ b/src/htdocs/js/general/NearbyPlacesView.js
@@ -23,7 +23,8 @@ var NearbyPlacesView = function (options) {
       _initialize,
 
       _errorMessage,
-      _formatter;
+      _formatter,
+      _xhr;
 
   _this = ProductView(options);
 
@@ -39,6 +40,10 @@ var NearbyPlacesView = function (options) {
    * Destroy all the things.
    */
   _this.destroy = Util.compose(function () {
+    if (_xhr) {
+      _xhr.abort();
+      _xhr = null;
+    }
     _errorMessage = null;
     _formatter = null;
     _this = null;
@@ -58,10 +63,13 @@ var NearbyPlacesView = function (options) {
       return;
     }
 
-    Xhr.ajax({
+    _xhr = Xhr.ajax({
       url: content.get('url'),
       success: _this.onSuccess,
-      error: _this.onError
+      error: _this.onError,
+      done: function () {
+        _xhr = null;
+      }
     });
   };
 


### PR DESCRIPTION
Fixes #308 

At least deals with errors that were appearing on the console.  Other views used outside the general module should also abort active Xhr requests during destroy.

The errors appear to be caused by repeated hashchange events when triggering window.location changes within the code.  When the page is loaded at '#map', and the user clicks the Close Map button, onBack changes the location using `window.location = '#general'`.  When this triggers onHashChange window.location.hash is not up to date and again sets `window.location = '#general'`.  This leads to a double render where the general module is created, destroyed before renders are complete, and recreated.