### PR TITLE
Issue-430

### DIFF
--- a/src/htdocs/js/core/Module.js
+++ b/src/htdocs/js/core/Module.js
@@ -135,10 +135,10 @@ var Module = function (options) {
     }
 
     product = null;
-    if (source !== null && code !== null) {
+    if (ev && source !== null && code !== null) {
       product = ev.getProductById(type, source, code, updateTime);
     }
-    if (product === null) {
+    if (ev && product === null) {
       product = ev.getPreferredProduct(type);
     }
     return product;

--- a/src/htdocs/js/core/Module.js
+++ b/src/htdocs/js/core/Module.js
@@ -100,6 +100,33 @@ var Module = function (options) {
   };
 
   /**
+   * Add "internal-" prefix or "-scenario" suffix to product "type".
+   *
+   * @param type {String}
+   *     The base product type.
+   *
+   * @return {String}
+   *     The actual product type depending on the current configuration.
+   */
+  _this.getFullType = function (type) {
+    var config,
+        fullType;
+
+    config = _this.model.get('config') || {};
+    fullType = type;
+
+    if (config.INTERNAL_MODE) {
+      fullType = 'internal-' + fullType;
+    }
+
+    if (config.SCENARIO_MODE) {
+      fullType += '-scenario';
+    }
+
+    return fullType;
+  };
+
+  /**
    * Get a product from the event based on module parameters and event config.
    *
    * Uses module parameters "source", "code", and optionally "updateTime".
@@ -115,7 +142,6 @@ var Module = function (options) {
    */
   _this.getProduct = function (type) {
     var code,
-        config,
         ev,
         params,
         product,
@@ -124,17 +150,12 @@ var Module = function (options) {
 
     ev = _this.model.get('event');
     params = _this.model.get(_this.ID) || {};
+    type = _this.getFullType(type);
     source = params.source || null;
     code = params.code || null;
     updateTime = params.updateTime || null;
-
-    config = _this.model.get('config');
-
-    if (config && config.SCENARIO_MODE === true) {
-      type += '-scenario';
-    }
-
     product = null;
+
     if (ev && source !== null && code !== null) {
       product = ev.getProductById(type, source, code, updateTime);
     }
@@ -155,15 +176,10 @@ var Module = function (options) {
    *     An array of the matching type of product. This might be an empty array.
    */
   _this.getProducts = function (type) {
-    var config,
-        catalogEvent;
+    var catalogEvent;
 
-    config = _this.model.get('config');
     catalogEvent = _this.model.get('event');
-
-    if (config && config.SCENARIO_MODE === true) {
-      type += '-scenario';
-    }
+    type = _this.getFullType(type);
 
     if (catalogEvent) {
       return catalogEvent.getProducts(type);

--- a/src/htdocs/js/map/InteractiveMapModule.js
+++ b/src/htdocs/js/map/InteractiveMapModule.js
@@ -70,7 +70,8 @@ var InteractiveMapModule = function (options) {
 
     _mapView = InteractiveMapView({
       formatter: options.formatter,
-      model: _this.model
+      model: _this.model,
+      module: _this
     });
 
     _modal = ModalView(_mapView.el, {

--- a/src/htdocs/js/map/InteractiveMapView.js
+++ b/src/htdocs/js/map/InteractiveMapView.js
@@ -334,8 +334,6 @@ var InteractiveMapView = function (options) {
         eventLatitude,
         eventLongitude;
 
-    // TODO :: Look at _this.model.event to see which overlays are available.
-    //         Returned object is keyed by display name for each layer.
     _overlays = {};
 
     catalogEvent = _this.model.get('event');

--- a/src/htdocs/js/map/InteractiveMapView.js
+++ b/src/htdocs/js/map/InteractiveMapView.js
@@ -362,14 +362,44 @@ var InteractiveMapView = function (options) {
     // case that a specific ?source=&code= were requested...
 
     // DYFI
-    _this.addDyfiOverlays(_module.getProduct('dyfi'));
+    _this.getProductOverlays('dyfi', _this.addDyfiOverlays);
 
     // ShakeMap
-    _this.addShakeMapOverlays(_module.getProduct('shakemap'));
+    _this.getProductOverlays('shakemap', _this.addShakeMapOverlays);
 
     return _overlays;
   };
 
+  _this.getProductOverlays = function (type, callback) {
+    var catalogEvent,
+        codeKey,
+        config,
+        product,
+        sourceKey;
+
+    catalogEvent = _this.model.get('event');
+
+    if (!catalogEvent) {
+      return;
+    }
+
+    config = Util.extend({}, _defaultConfig, _this.model.get('map'));
+    sourceKey = type + 'Source';
+    codeKey = type + 'Code';
+    type = _module.getFullType(type);
+
+    if (config.hasOwnProperty(sourceKey) &&
+        config.hasOwnProperty(codeKey)) {
+      product = catalogEvent.getProductById(type, config[sourceKey],
+          config[codeKey]);
+    } else {
+      product = catalogEvent.getPreferredProduct(type);
+    }
+
+    if (product) {
+      callback(product);
+    }
+  };
   /**
    * Called to notify the view that it's element is now in the DOM so
    * things like dimensions can be inspected etc...

--- a/src/htdocs/js/shakemap/ShakeMapView.js
+++ b/src/htdocs/js/shakemap/ShakeMapView.js
@@ -182,12 +182,15 @@ var ShakeMapView = function (options) {
     }
 
     // In addition to contours (default), enable stations
-    link = '<a href="#map?' + InteractiveMapView.SHAKEMAP_STATIONS + '=true">' +
+    link =
+      '<a href="#map?' + InteractiveMapView.SHAKEMAP_STATIONS + '=true' +
+          '&source=' + _this.model.get('source') +
+          '&code=' + _this.model.get('code') + '">' +
         '<img' +
           ' src="' + content.get('url') + '"' +
           ' alt="' + alt + '"' +
         '/>' +
-        '</a>';
+      '</a>';
 
     return link;
   };

--- a/src/htdocs/js/shakemap/ShakeMapView.js
+++ b/src/htdocs/js/shakemap/ShakeMapView.js
@@ -184,8 +184,8 @@ var ShakeMapView = function (options) {
     // In addition to contours (default), enable stations
     link =
       '<a href="#map?' + InteractiveMapView.SHAKEMAP_STATIONS + '=true' +
-          '&source=' + _this.model.get('source') +
-          '&code=' + _this.model.get('code') + '">' +
+          '&shakemapSource=' + _this.model.get('source') +
+          '&shakemapCode=' + _this.model.get('code') + '">' +
         '<img' +
           ' src="' + content.get('url') + '"' +
           ' alt="' + alt + '"' +


### PR DESCRIPTION
fixes usgs/earthquake-eventpages#430

Added support to use overlays from specific products. To use this, pages must link to:

`#map?type+Source=productSource&type+Code=productCode`
Where "type" is the product type (like shakemap), so for example:

`#map?ShakeMap Stations=true&shakemapSource=ak&shakemapCode=ak12969564`

BTW: Test this PR using event id us10004x1w and verify network console is fetching cont_mi for the appropriate product depending on which image was clicked.