### PR TITLE
Update event pages to use latest version of quakeml-parser-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "postcss-calc": "^5.0.0",
     "postcss-import": "^7.1.0",
     "precss": "^1.3.0",
-    "quakeml-parser-js": "0.0.2",
+    "quakeml-parser-js": "usgs/quakeml-parser-js",
     "sinon": "^1.17.1"
   },
   "engines": {


### PR DESCRIPTION
Depends on usgs/quakeml-parser-js#6

Fixes #458