### PR TITLE
Combine offsite_host proxy sections, add urls to be proxied

### DIFF
--- a/gruntconfig/connect.js
+++ b/gruntconfig/connect.js
@@ -43,31 +43,15 @@ var connect = {
       }
     },
     {
-      context: '/realtime/',
-      headers: {
-        host: OFFSITE_HOST
-      },
-      host: OFFSITE_HOST,
-      port: 80
-    },
-    {
-      context: '/archive/',
-      headers: {
-        host: OFFSITE_HOST
-      },
-      host: OFFSITE_HOST,
-      port: 80
-    },
-    {
-      context: '/product/',
-      headers: {
-        host: OFFSITE_HOST
-      },
-      host: OFFSITE_HOST,
-      port: 80
-    },
-    {
-      context: '/scenario/',
+      context: [
+        '/archive/',
+        '/data/',
+        '/product/',
+        '/realtime/',
+        '/scenario/',
+        '/scenarios/',
+        '/ws/'
+      ],
       headers: {
         host: OFFSITE_HOST
       },


### PR DESCRIPTION
Fixes #482 

The default attribution url set by pre-install works with the updated proxy configuration.