### PR TITLE
Focal mechanism plotting

### DIFF
--- a/src/htdocs/js/core/SummaryModule.js
+++ b/src/htdocs/js/core/SummaryModule.js
@@ -202,7 +202,7 @@ var SummaryModule = function (options) {
 
     markup.push('<a href="#' + module.ID + '?source=' + product.get('source') +
         '&amp;code=' + product.get('code') + '">' +
-      product.getProperty('eventsource').toUpperCase() +
+      (product.getProperty('eventsource') || 'N/A').toUpperCase() +
     '</a>');
 
     return markup.join('');

--- a/src/htdocs/js/moment-tensor/BeachBallView.js
+++ b/src/htdocs/js/moment-tensor/BeachBallView.js
@@ -434,6 +434,9 @@ var BeachBallView = function (options) {
       sfi = Math.sin(fir);
       cfi = Math.cos(fir);
       s2alphan = (2 + 2 * iso) / (3 + (1 - 2 * f) * Math.cos(2 * fir));
+      if (Math.abs(1 - s2alphan) <= Number.EPSILON) {
+        s2alphan = 1;
+      }
       if (s2alphan > 1) {
         // swap axes
         tmp = t;


### PR DESCRIPTION
Fix for focal-mechanism plotting bug reported by ghayes.

Page with bug (and screenshot); background colors are flipped from what is expected:
http://earthquake.usgs.gov/earthquakes/eventpage/usp0009qb4#focal-mechanism?source=us&code=pde20000328110022510_126_B_US
![fm_bug](https://cloud.githubusercontent.com/assets/1717896/15298239/945c5844-1b5b-11e6-80fc-d3683bdc2a64.png)


Page with expected plot (and screenshot); background colors are correct:
http://earthquake.usgs.gov/earthquakes/eventpage/usp0009qb4#focal-mechanism?source=us&code=choy20000328110022
![fm_expected](https://cloud.githubusercontent.com/assets/1717896/15298267/b6d8b4ee-1b5b-11e6-98d4-3cfa0b91b7bf.png)


Seems to be related to the first FM including a scalar moment, and the s2alphan parameter becoming greater than 1.  This addresses by checking if s2alphan is within epsilon of 1 before considering it greater than 1.
