### PR TITLE
Incorrect shading on beachballs

### DIFF
--- a/src/htdocs/js/moment-tensor/BeachBallView.js
+++ b/src/htdocs/js/moment-tensor/BeachBallView.js
@@ -440,7 +440,7 @@ var BeachBallView = function (options) {
         t = p;
         p = tmp;
         // swap bg/fill colors
-        swapColors = !swapColors;
+        swapColors = true;
         // recompute f, iso, s2alphan
         f = (-n.v / t.v) || Number.EPSILON;
         iso = (vi / t.v) || Number.EPSILON;


### PR DESCRIPTION
Update swapColors flag to not change once it is set. The flag was get ting set twice and not swapping the colors.

fixes #520 
