### PR TITLE
Add class name to Latest Earthquakes link in navigation

### DIFF
--- a/src/htdocs/js/core/EventPage.js
+++ b/src/htdocs/js/core/EventPage.js
@@ -248,6 +248,7 @@ var EventPage = function (options) {
       link.setAttribute('class', 'latest-earthquakes');
       link.setAttribute('href', '/earthquakes/map/');
       link.innerHTML = 'Latest Earthquakes';
+      link.classList.add('up-one-level');
       el.appendChild(link);
     }
   };


### PR DESCRIPTION
This class name is used by the template to style the "up-on-level" link in the naviation