### PR TITLE
Issue-580

### DIFF
--- a/src/htdocs/js/dyfi/DYFIFormModule.js
+++ b/src/htdocs/js/dyfi/DYFIFormModule.js
@@ -258,18 +258,22 @@ var DYFIFormModule = function (options) {
    *
    */
   _this.onSubmit = function () {
-    var data;
+    var data,
+        ev;
 
     _submitResult = null;
 
+    ev = _this.model.get('event');
+
     data = Util.extend({
+      eventid: ev ? ev.getEventId() : null,
       form_version: _formVersion,
       ciim_report: 'Submit Form'
     }, _formModel.get());
 
     Xhr.ajax({
       method: 'POST',
-      data: _formModel.get(),
+      data: data,
       error: _this.onSubmitError,
       url: _submitUrl,
       success: _this.onSubmitSuccess


### PR DESCRIPTION
fixes usgs/earthquake-eventpages#580

Produces results response files similar to the attached.

[dyfi-response-example.txt](https://github.com/usgs/earthquake-eventpages/files/352572/dyfi-response-example.txt)
