### PR TITLE
Issue-554

### DIFF
--- a/example/_navigation.inc.php
+++ b/example/_navigation.inc.php
@@ -39,13 +39,18 @@ print navGroup('Scientific',
     navItem('/moment-tensor/BeachBallViewExample.php', 'BeachBallView') .
     navItem('/finite-fault/FiniteFaultPinViewExample.php', 'FiniteFaultPinView') .
     navItem('/finite-fault/FiniteFaultViewExample.php', 'FiniteFaultView') .
-    navItem('/focal-mechanism/FocalMechanismViewExample.php', 'FocalMechanismView') .
+    navItem('/focal-mechanism/FocalMechanismPinViewExample.php',
+        'FocalMechanismPinView') .
+    navItem('/focal-mechanism/FocalMechanismViewExample.php',
+        'FocalMechanismView') .
     navItem('/origin/MagnitudesViewExample.php', 'MagnitudesView') .
-    navItem('/origin/OriginViewExample.php', 'OriginView') .
     navItem('/origin/OriginPinViewExample.php', 'OriginPinView') .
+    navItem('/origin/OriginViewExample.php', 'OriginView') .
     navItem('/origin/PhasesViewExample.php', 'PhasesView') .
-    navItem('/moment-tensor/MomentTensorViewExample.php', 'MomentTensorView') .
-    navItem('/moment-tensor/MomentTensorPinViewExample.php', 'MomentTensorPinView')
+    navItem('/moment-tensor/MomentTensorPinViewExample.php',
+        'MomentTensorPinView') .
+    navItem('/moment-tensor/MomentTensorViewExample.php',
+        'MomentTensorView')
   );
 
 ?>

--- a/example/focal-mechanism/FocalMechanismPinViewExample.js
+++ b/example/focal-mechanism/FocalMechanismPinViewExample.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var FocalMechanismPinView = require('focal-mechanism/FocalMechanismPinView'),
+    Product = require('pdl/Product');
+
+
+var product;
+
+product = Product({
+  "indexid": "96074781",
+  "indexTime": 1466734851557,
+  "id": "urn:usgs-product:ci:focal-mechanism:ci37611456_fm1:1466734848800",
+  "type": "focal-mechanism",
+  "code": "ci37611456_fm1",
+  "source": "ci",
+  "updateTime": 1466734848800,
+  "status": "UPDATE",
+  "properties": {
+    "beachball-source": "CI",
+    "depth": "9.28",
+    "evaluation-status": "preliminary",
+    "eventParametersPublicID": "quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37611456",
+    "eventsource": "ci",
+    "eventsourcecode": "37611456",
+    "eventtime": "2016-06-24T01:46:35.180Z",
+    "latitude": "33.9916667",
+    "longitude": "-118.5236667",
+    "nodal-plane-1-dip": "78.0",
+    "nodal-plane-1-rake": "-171.0",
+    "nodal-plane-1-strike": "295.0",
+    "nodal-plane-2-dip": "81.0",
+    "nodal-plane-2-rake": "-12.0",
+    "nodal-plane-2-strike": "203.0",
+    "num-stations-used": "0",
+    "original-eventsource": "ci",
+    "original-eventsourcecode": "37611456",
+    "quakeml-publicid": "quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?mecid=3191533",
+    "review-status": "automatic"
+  },
+  "preferredWeight": 156,
+  "contents": {
+    "ci37611456.cifm1.html": {
+      "contentType": "text/html",
+      "lastModified": 1466734847000,
+      "length": 4013,
+      "url": "/archive/product/focal-mechanism/ci37611456_fm1/ci/1466734848800/ci37611456.cifm1.html"
+    },
+    "ci37611456.cifm1.jpg": {
+      "contentType": "image/jpeg",
+      "lastModified": 1466734847000,
+      "length": 627235,
+      "url": "/archive/product/focal-mechanism/ci37611456_fm1/ci/1466734848800/ci37611456.cifm1.jpg"
+    },
+    "contents.xml": {
+      "contentType": "application/xml",
+      "lastModified": 1466734848000,
+      "length": 365,
+      "url": "/archive/product/focal-mechanism/ci37611456_fm1/ci/1466734848800/contents.xml"
+    },
+    "quakeml.xml": {
+      "contentType": "application/xml",
+      "lastModified": 1466734848000,
+      "length": 3274,
+      "url": "/archive/product/focal-mechanism/ci37611456_fm1/ci/1466734848800/quakeml.xml"
+    }
+  }
+});
+
+FocalMechanismPinView({
+  el: document.querySelector('.focal-mechanism-pin-view-example'),
+  model: product
+}).render();

--- a/example/focal-mechanism/FocalMechanismPinViewExample.php
+++ b/example/focal-mechanism/FocalMechanismPinViewExample.php
@@ -1,0 +1,32 @@
+<?php
+if (!isset($TEMPLATE)) {
+
+  $TITLE = 'FocalMechanismPinView';
+
+  // If you want to include section navigation.
+  // The nearest _navigation.inc.php file will be used by default
+  $NAVIGATION = true;
+
+  // Stuff that goes at the top of the page (in the <head>) (i.e. <link> tags)
+  $HEAD = '
+    <link rel="stylesheet" href="/css/event.css"/>
+    <style>
+      .focal-mechanism-pin-view-example {
+        height: 310px;
+        margin-top: 1em;
+        width: 210px;
+      }
+    </style>
+  ';
+
+  // Stuff that goes at the bottom of the page (i.e. <script> tags)
+  $FOOT = '
+    <script src="/js/classes.js"></script>
+    <script src="FocalMechanismPinViewExample.js"></script>
+  ';
+
+  include 'template.inc.php';
+}
+?>
+
+<div class="focal-mechanism-pin-view-example"></div>

--- a/gruntconfig/browserify.js
+++ b/gruntconfig/browserify.js
@@ -43,6 +43,7 @@ var ALL_CLASSES = [
   JS + '/finite-fault/FiniteFaultView.js:finite-fault/FiniteFaultView',
 
   JS + '/focal-mechanism/FocalMechanismModule.js:focal-mechanism/FocalMechanismModule',
+  JS + '/focal-mechanism/FocalMechanismPinView.js:focal-mechanism/FocalMechanismPinView',
   JS + '/focal-mechanism/FocalMechanismView.js:focal-mechanism/FocalMechanismView',
 
   JS + '/general/ExecutiveSummaryModule.js:general/ExecutiveSummaryModule',

--- a/src/htdocs/css/event.scss
+++ b/src/htdocs/css/event.scss
@@ -44,6 +44,8 @@
 
 @import 'finite-fault/_FiniteFaultPinView.scss';
 
+@import 'focal-mechanism/_FocalMechanismPinView.scss';
+
 @import 'general/_ExecutiveSummaryModule.scss';
 @import 'general/_GeneralSummary.scss';
 @import 'general/_LocationMap.scss';

--- a/src/htdocs/css/focal-mechanism/_FocalMechanismPinView.scss
+++ b/src/htdocs/css/focal-mechanism/_FocalMechanismPinView.scss
@@ -1,0 +1,3 @@
+.focal-mechanism-pin-beachball {
+  margin: 1em auto;
+}

--- a/src/htdocs/js/focal-mechanism/FocalMechanismPinView.js
+++ b/src/htdocs/js/focal-mechanism/FocalMechanismPinView.js
@@ -1,0 +1,36 @@
+'use strict';
+
+
+var FocalMechanismModule = require('focal-mechanism/FocalMechanismModule'),
+    MomentTensorPinView = require('moment-tensor/MomentTensorPinView'),
+    Util = require('util/Util');
+
+
+var _DEFAULTS = {
+  className: 'focal-mechanism-pin-beachball',
+  fillColor: '#ffaa69',
+  module: FocalMechanismModule
+};
+
+
+/**
+ * This view is used for rendering a focal mechanism pin. Currently it
+ * does the same thing as the {MomentTensorPinView} (i.e. a beachball), but
+ * uses a different color and className by default.
+ *
+ * @see {moment-tensor/MomentTensorPinView}
+ */
+var FocalMechanismPinView = function (options) {
+  var _this;
+
+
+  options = Util.extend({}, _DEFAULTS, options);
+  _this = MomentTensorPinView(options);
+
+
+  options = null;
+  return _this;
+};
+
+
+module.exports = FocalMechanismPinView;

--- a/src/htdocs/js/general/ExecutiveSummaryModule.js
+++ b/src/htdocs/js/general/ExecutiveSummaryModule.js
@@ -4,7 +4,7 @@
 var DyfiFormPinView = require('dyfi/DYFIFormPinView'),
     DyfiPinView = require('dyfi/DYFIPinView'),
     FiniteFaultPinView = require('finite-fault/FiniteFaultPinView'),
-    FocalMechanismPinView = require('core/BasicPinView'), // TODO
+    FocalMechanismPinView = require('focal-mechanism/FocalMechanismPinView'),
     ImpactPinView = require('impact/ImpactPinView'),
     InteractiveMapPinView = require('map/InteractiveMapPinView'),
     MomentTensorPinView = require('moment-tensor/MomentTensorPinView'),
@@ -266,8 +266,8 @@ var ExecutiveSummaryModule = function (options) {
       // Only show focal mechanism if no moment tensor
 
       // Focal Mechanism pin
-      product = ev.getPreferredProduct(Product.getFullType('focal-mechanism',
-          config));
+      product = ev.getPreferredProduct(Product.getFullType(
+          'focal-mechanism', config));
       if (product) {
         _this.pinViews.push(FocalMechanismPinView({
           el: _this.createPinContainer(list),

--- a/test/spec/focal-mechanism/FocalMechanismPinViewTest.js
+++ b/test/spec/focal-mechanism/FocalMechanismPinViewTest.js
@@ -1,0 +1,31 @@
+/* global chai, describe, it */
+'use strict';
+
+
+var FocalMechanismPinView = require('focal-mechanism/FocalMechanismPinView');
+
+
+var expect = chai.expect;
+
+
+describe('focal-mechanism/FocalMechanismPinView', function () {
+  describe('constructor', function () {
+    it('is defined', function () {
+      expect(typeof FocalMechanismPinView).to.equal('function');
+    });
+
+    it('can be instantiated', function () {
+      expect(FocalMechanismPinView).to.not.throw(Error);
+    });
+
+    it('can be destroyed', function () {
+      var view;
+
+      view = FocalMechanismPinView();
+
+      expect(view.destroy).to.not.throw(Error);
+
+      view.destroy();
+    });
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -60,6 +60,7 @@ require('./spec/finite-fault/FiniteFaultPinViewTest');
 require('./spec/finite-fault/FiniteFaultViewTest');
 
 require('./spec/focal-mechanism/FocalMechanismModuleTest');
+require('./spec/focal-mechanism/FocalMechanismPinViewTest');
 require('./spec/focal-mechanism/FocalMechanismViewTest');
 
 require('./spec/general/ExecutiveSummaryModuleTest');


### PR DESCRIPTION
fixes usgs/earthquake-eventpages#554

Since moment tensors take precedence over focal mechanisms, you must find and event with a FM but not an MT in order to see this on the executive summary.

eg. ci37611456