### PR TITLE
Issue-555

### DIFF
--- a/gruntconfig/connect.js
+++ b/gruntconfig/connect.js
@@ -44,6 +44,7 @@ var connect = {
     },
     {
       context: [
+        '/arcgis/',
         '/archive/',
         '/data/',
         '/product/',

--- a/src/htdocs/css/general/_RegionalInfoModule.scss
+++ b/src/htdocs/css/general/_RegionalInfoModule.scss
@@ -1,5 +1,5 @@
 .regional-info-module-map {
-  cursor: text;
+  cursor: pointer;
   height: 310px;
   margin-bottom: 1em;
 }

--- a/src/htdocs/js/map/InteractiveMapView.js
+++ b/src/htdocs/js/map/InteractiveMapView.js
@@ -26,7 +26,9 @@ var _DYFI_10K_OVERLAY = 'DYFI Responses 10 km',
     _DYFI_DEFAULT_OVERLAY = 'DYFI Responses',
     _EPICENTER_OVERLAY = 'Epicenter',
     _FAULTS_OVERLAY = 'U.S. Faults',
+    _HIST_SEIS_OVERLAY = 'Historical Seismicity',
     _PLATES_OVERLAY = 'Tectonic Plates',
+    _POPULATION_OVERLAY = 'Population Density',
     _SHAKEMAP_CONTOURS = 'ShakeMap MMI Contours',
     _SHAKEMAP_STATIONS = 'ShakeMap Stations';
 
@@ -498,7 +500,9 @@ InteractiveMapView.DYFI_1K_OVERLAY = _DYFI_1K_OVERLAY;
 InteractiveMapView.DYFI_DEFAULT_OVERLAY = _DYFI_DEFAULT_OVERLAY;
 InteractiveMapView.EPICENTER_OVERLAY = _EPICENTER_OVERLAY;
 InteractiveMapView.FAULTS_OVERLAY = _FAULTS_OVERLAY;
+InteractiveMapView.HIST_SEIS_OVERLAY = _HIST_SEIS_OVERLAY;
 InteractiveMapView.PLATES_OVERLAY = _PLATES_OVERLAY;
+InteractiveMapView.POPULATION_OVERLAY = _POPULATION_OVERLAY;
 InteractiveMapView.SHAKEMAP_CONTOURS = _SHAKEMAP_CONTOURS;
 InteractiveMapView.SHAKEMAP_STATIONS = _SHAKEMAP_STATIONS;
 


### PR DESCRIPTION
fixes usgs/earthquake-eventpages#555

Does not yet include population density overlay as that tile layer service is not ready. A separate ticket can be created when that is available.

Also, the interactive map does not yet support display for either of these layers. The link is properly formatted however such that when the interactive map supports display for the layer, the link will work as expected.