### PR TITLE
Remove DYFIFormView.render from DYFIFormModule.showForm method

### DIFF
--- a/src/htdocs/js/dyfi/DYFIFormModule.js
+++ b/src/htdocs/js/dyfi/DYFIFormModule.js
@@ -163,6 +163,7 @@ var DYFIFormModule = function (options) {
     _view = DYFIFormView({
       model: _formModel
     });
+    _view.render();
 
     _modal = ModalView(_view.el, {
       buttons: [
@@ -378,9 +379,6 @@ var DYFIFormModule = function (options) {
 
     // Ensure submit button status is currently up-to-date
     _this.onFormChange();
-
-    // Render after modal is shown so content is in DOM
-    _view.render();
   };
 
 


### PR DESCRIPTION
This was duplicating the form markup when you show/hide the DYFI Tell Us! form

fixes #659 

Turns out the iOS issue was just connection issue where our mobile devices could not access the response page to post the form data. 