### PR TITLE
When the log tick scale is not used, make sure numbers are whole numbers

### DIFF
--- a/src/htdocs/js/dyfi/DYFIIntensityGraphView.js
+++ b/src/htdocs/js/dyfi/DYFIIntensityGraphView.js
@@ -289,10 +289,9 @@ var DYFIIntensityGraphView = function (options) {
     logmax = Math.log(max) / Math.LN10;
 
     // range is completely within 2 ticks on the log 10 scale.
-    // Create 2 ticks, rounded to the nearest 1000's.
+    // Create 2 ticks, rounded to the nearest whole number.
     if (logmax - logmin < 1) {
-      ticks = [Math.round(min * 1000.0) / 1000.0,
-          Math.round(max * 1000.0) / 1000.0];
+      ticks = [Math.round(min), Math.round(max)];
       return ticks;
     }
 


### PR DESCRIPTION
fixes #664 