### PR TITLE
Origin Pin Component

### DIFF
--- a/src/app/executive/executive.module.ts
+++ b/src/app/executive/executive.module.ts
@@ -1,13 +1,38 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import {
+  MatCard,
+  MatCardTitle,
+  MatCardTitleGroup,
+  MatCardContent,
+  MatCardImage,
+  MatCardActions,
+  MatCardFooter
+} from '@angular/material';
+
 import { ExecutiveComponent } from './executive/executive.component';
+import { OriginPinComponent } from './origin-pin/origin-pin.component';
+
+import { ProductPageModule } from '../product-page/product-page.module';
 import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
   imports: [
     CommonModule,
+    ProductPageModule,
     SharedModule
   ],
-  declarations: [ExecutiveComponent]
+  declarations: [
+    ExecutiveComponent,
+    MatCard,
+    MatCardTitle,
+    MatCardTitleGroup,
+    MatCardContent,
+    MatCardImage,
+    MatCardActions,
+    MatCardFooter,
+    OriginPinComponent
+
+  ]
 })
 export class ExecutiveModule { }

--- a/src/app/executive/executive.module.ts
+++ b/src/app/executive/executive.module.ts
@@ -12,12 +12,14 @@ import { RouterModule } from '@angular/router';
 import { ExecutiveComponent } from './executive/executive.component';
 import { OriginPinComponent } from './origin-pin/origin-pin.component';
 
+import { EventPageModule } from '../event-page/event-page.module';
 import { ProductPageModule } from '../product-page/product-page.module';
 import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
   imports: [
     CommonModule,
+    EventPageModule,
     ProductPageModule,
     SharedModule,
     MatListModule,

--- a/src/app/executive/executive.module.ts
+++ b/src/app/executive/executive.module.ts
@@ -1,14 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
-  MatCard,
-  MatCardTitle,
-  MatCardTitleGroup,
-  MatCardContent,
-  MatCardImage,
-  MatCardActions,
-  MatCardFooter
+  MatButtonModule,
+  MatCardModule,
+  MatDividerModule,
+  MatListModule
 } from '@angular/material';
+import { RouterModule } from '@angular/router';
+
 
 import { ExecutiveComponent } from './executive/executive.component';
 import { OriginPinComponent } from './origin-pin/origin-pin.component';
@@ -20,19 +19,16 @@ import { SharedModule } from '../shared/shared.module';
   imports: [
     CommonModule,
     ProductPageModule,
-    SharedModule
+    SharedModule,
+    MatListModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDividerModule,
+    RouterModule
   ],
   declarations: [
     ExecutiveComponent,
-    MatCard,
-    MatCardTitle,
-    MatCardTitleGroup,
-    MatCardContent,
-    MatCardImage,
-    MatCardActions,
-    MatCardFooter,
     OriginPinComponent
-
   ]
 })
 export class ExecutiveModule { }

--- a/src/app/executive/executive/executive.component.css
+++ b/src/app/executive/executive/executive.component.css
@@ -1,0 +1,36 @@
+.executive-summary-pins {
+  list-style: none;
+  padding: 1em 0;
+  margin: 1em 0;
+}
+
+.executive-summary-pin {
+  margin: 1em 1em 0 0;
+  overflow: visible;
+  width: 100%;
+}
+
+.pin-view {
+  border: 1px solid #ededed;
+  border-radius: 2px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+@media screen and (min-width: 32em) {
+  .executive-summary-pins {
+    margin: 0 0 1em -1em;
+    overflow: hidden;
+  }
+
+  .executive-summary-pin {
+    float: left;
+    margin: 1em 0 0 1em;
+    width: 15em;
+  }
+}

--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -2,7 +2,10 @@
 
   <ul class="executive-summary-pins">
     <li class="executive-summary-pin">
-      <app-origin-pin class="pin-view"></app-origin-pin>
+      <app-origin-pin class="pin-view"
+          [contributors]="contributorService.contributors$ | async"
+          [event]="event">
+      </app-origin-pin>
     </li>
   </ul>
 

--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -1,6 +1,10 @@
 <ng-container *ngIf="eventService.event$ | async; let event">
 
-  <app-origin-pin></app-origin-pin>
+  <ul class="executive-summary-pins">
+    <li class="executive-summary-pin">
+      <app-origin-pin class="pin-view"></app-origin-pin>
+    </li>
+  </ul>
 
   <shared-text-product
       *ngFor="let product of event.getProducts('general-text')"

--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -1,9 +1,6 @@
-<p>
-  executive component works!
-</p>
-
-
 <ng-container *ngIf="eventService.event$ | async; let event">
+
+  <app-origin-pin></app-origin-pin>
 
   <shared-text-product
       *ngFor="let product of event.getProducts('general-text')"

--- a/src/app/executive/executive/executive.component.scss
+++ b/src/app/executive/executive/executive.component.scss
@@ -17,9 +17,25 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  margin: 0;
+  margin: 0 auto;
   padding: 0;
-  width: 100%;
+  width: 15em;
+
+  mat-card {
+    cursor: pointer;
+  }
+
+  mat-card:hover {
+    background: rgba(0,0,0,0.03);
+  }
+
+  mat-card:active {
+    background: rgba(0,0,0,0.1);
+  }
+
+  mat-card-content {
+    margin: 2em 0;
+  }
 }
 
 @media screen and (min-width: 32em) {

--- a/src/app/executive/executive/executive.component.spec.ts
+++ b/src/app/executive/executive/executive.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ExecutiveComponent } from './executive.component';
 import { MockComponent } from 'ng2-mock-component';
 import { EventService } from '../../event.service';
+import { ContributorService } from '../../contributor.service';
 
 describe('ExecutiveComponent', () => {
   let component: ExecutiveComponent;
@@ -16,11 +17,13 @@ describe('ExecutiveComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         ExecutiveComponent,
+        MockComponent({ selector: 'app-origin-pin', inputs: ['event', 'contributors']}),
         MockComponent({ selector: 'shared-link-product', inputs: ['product']}),
         MockComponent({ selector: 'shared-text-product', inputs: ['product']})
       ],
       providers: [
-        { provide: EventService, useValue: eventServiceStub }
+        { provide: EventService, useValue: eventServiceStub },
+        { provide: ContributorService, useValue: {} }
       ]
     })
     .compileComponents();

--- a/src/app/executive/executive/executive.component.ts
+++ b/src/app/executive/executive/executive.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { EventService } from '../../event.service';
+import { ContributorService } from '../../contributor.service';
 
 @Component({
   selector: 'app-executive',
@@ -9,7 +10,8 @@ import { EventService } from '../../event.service';
 export class ExecutiveComponent implements OnInit {
 
   constructor (
-    public eventService: EventService
+    public eventService: EventService,
+    public contributorService: ContributorService
   ) { }
 
   ngOnInit () {

--- a/src/app/executive/executive/executive.component.ts
+++ b/src/app/executive/executive/executive.component.ts
@@ -1,11 +1,12 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { EventService } from '../../event.service';
 import { ContributorService } from '../../contributor.service';
 
 @Component({
   selector: 'app-executive',
   templateUrl: './executive.component.html',
-  styleUrls: ['./executive.component.css']
+  styleUrls: ['./executive.component.scss'],
+  encapsulation: ViewEncapsulation.None
 })
 export class ExecutiveComponent implements OnInit {
 

--- a/src/app/executive/origin-pin/origin-pin.component.html
+++ b/src/app/executive/origin-pin/origin-pin.component.html
@@ -4,7 +4,8 @@
       {{ title }}
     </mat-card-title>
     <mat-card-subtitle>
-      Contributed by {{ product.source }}
+      Contributed by
+      <span [innerHTML]="product | contributorList:event:contributors"></span>
     </mat-card-subtitle>
     <mat-card-content>
       <dl>
@@ -24,10 +25,5 @@
     <mat-card-actions>
       <a mat-button color="primary" [routerLink]="'../origin'">View Origin Details</a>
     </mat-card-actions>
-<!--
-    <mat-card-footer>
-      <span>Contributed by {{ product.source }}</span>
-    </mat-card-footer>
- -->
   </mat-card>
 </ng-container>

--- a/src/app/executive/origin-pin/origin-pin.component.html
+++ b/src/app/executive/origin-pin/origin-pin.component.html
@@ -1,0 +1,29 @@
+<ng-container *ngIf="product; else noProduct">
+  <pre>{{ toJson(product) }}</pre>
+  <mat-card>
+    <mat-card-title>
+      <h1>{{ title }}</h1>
+    </mat-card-title>
+    <mat-card-content>
+      <dl>
+        <dt>Review Status</dt>
+        <dd>{{ product.properties['review-status'] }}</dd>
+
+        <dt>Magnitude</dt>
+        <dd>{{ product.properties.magnitude }}</dd>
+
+        <dt>Depth</dt>
+        <dd>{{ product.properties.depth }}</dd>
+
+        <dt>Time</dt>
+        <dd>{{ product.properties.time | dateTime }}</dd>
+      </dl>
+    </mat-card-content>
+    <mat-card-actions>
+      <button>{{ actions }}</button>
+    </mat-card-actions>
+    <mat-card-footer>
+      <p>{{ footer }}</p>
+    </mat-card-footer>
+  </mat-card>
+</ng-container>

--- a/src/app/executive/origin-pin/origin-pin.component.html
+++ b/src/app/executive/origin-pin/origin-pin.component.html
@@ -1,29 +1,33 @@
-<ng-container *ngIf="product; else noProduct">
-  <pre>{{ toJson(product) }}</pre>
-  <mat-card>
+<ng-container *ngIf="product">
+  <mat-card [routerLink]="'../origin'">
     <mat-card-title>
-      <h1>{{ title }}</h1>
+      {{ title }}
     </mat-card-title>
+    <mat-card-subtitle>
+      Contributed by {{ product.source }}
+    </mat-card-subtitle>
     <mat-card-content>
       <dl>
         <dt>Review Status</dt>
-        <dd>{{ product.properties['review-status'] }}</dd>
+        <dd>{{ product.properties['review-status'].toUpperCase() }}</dd>
 
         <dt>Magnitude</dt>
-        <dd>{{ product.properties.magnitude }}</dd>
+        <dd>{{ product.properties.magnitude }} {{ product.properties['magnitude-type'] }}</dd>
 
         <dt>Depth</dt>
-        <dd>{{ product.properties.depth }}</dd>
+        <dd>{{ this.formatterService.depth(product.properties.depth, 'km') }}</dd>
 
         <dt>Time</dt>
-        <dd>{{ product.properties.time | dateTime }}</dd>
+        <dd>{{ product.properties.eventtime | date:"yyyy-MM-dd HH:mm:ss":"UTC" }} (UTC)</dd>
       </dl>
     </mat-card-content>
     <mat-card-actions>
-      <button>{{ actions }}</button>
+      <a mat-button color="primary" [routerLink]="'../origin'">View Origin Details</a>
     </mat-card-actions>
+<!--
     <mat-card-footer>
-      <p>{{ footer }}</p>
+      <span>Contributed by {{ product.source }}</span>
     </mat-card-footer>
+ -->
   </mat-card>
 </ng-container>

--- a/src/app/executive/origin-pin/origin-pin.component.scss
+++ b/src/app/executive/origin-pin/origin-pin.component.scss
@@ -1,0 +1,31 @@
+mat-card {
+  cursor: pointer;
+}
+
+mat-card:hover {
+  background: rgba(0,0,0,0.03);
+}
+
+mat-card:active {
+  background: rgba(0,0,0,0.1);
+}
+
+mat-card-content {
+  margin: 2em 0;
+}
+
+mat-card-footer {
+  border-top: 1px solid #ededed;
+  margin: 0;
+  padding: 1em 0 0;
+  text-align: center;
+}
+
+dt {
+  font-weight: 500;
+}
+
+dd {
+  margin: 0.25em 0 1em;
+  padding: 0;
+}

--- a/src/app/executive/origin-pin/origin-pin.component.scss
+++ b/src/app/executive/origin-pin/origin-pin.component.scss
@@ -1,31 +1,8 @@
-mat-card {
-  cursor: pointer;
-}
-
-mat-card:hover {
-  background: rgba(0,0,0,0.03);
-}
-
-mat-card:active {
-  background: rgba(0,0,0,0.1);
-}
-
-mat-card-content {
-  margin: 2em 0;
-}
-
-mat-card-footer {
-  border-top: 1px solid #ededed;
-  margin: 0;
-  padding: 1em 0 0;
-  text-align: center;
-}
-
 dt {
   font-weight: 500;
 }
 
 dd {
-  margin: 0.25em 0 1em;
+  margin: 0 0 1em;
   padding: 0;
 }

--- a/src/app/executive/origin-pin/origin-pin.component.spec.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OriginPinComponent } from './origin-pin.component';
+
+describe('OriginPinComponent', () => {
+  let component: OriginPinComponent;
+  let fixture: ComponentFixture<OriginPinComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ OriginPinComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OriginPinComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/executive/origin-pin/origin-pin.component.spec.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.spec.ts
@@ -1,14 +1,45 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatDividerModule,
+  MatListModule
+} from '@angular/material';
+import { MockPipe } from '../../mock-pipe';
 
 import { OriginPinComponent } from './origin-pin.component';
+
+import { EventService } from '../../event.service';
+import { FormatterService } from '../../formatter.service';
 
 describe('OriginPinComponent', () => {
   let component: OriginPinComponent;
   let fixture: ComponentFixture<OriginPinComponent>;
 
   beforeEach(async(() => {
+    const eventServiceStub = {
+      getEvent: jasmine.createSpy('eventService::getEvent'),
+      getProduct: jasmine.createSpy('eventService::getProduct')
+    };
+
     TestBed.configureTestingModule({
-      declarations: [ OriginPinComponent ]
+      declarations: [
+        OriginPinComponent,
+
+        MockPipe('contributorList')
+      ],
+      imports: [
+        MatListModule,
+        MatButtonModule,
+        MatCardModule,
+        MatDividerModule,
+        RouterModule
+      ],
+      providers: [
+        { provide: EventService, useValue: eventServiceStub },
+        { provide: FormatterService, useValue: {} }
+      ]
     })
     .compileComponents();
   }));

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { Subscription } from 'rxjs/Subscription';
@@ -14,7 +14,11 @@ import { Event } from '../../event';
   styleUrls: ['./origin-pin.component.scss']
 })
 export class OriginPinComponent implements OnInit {
+  @Input() contributors: any;
+  @Input() event: any;
+
   title: string = 'Origin';
+  product: any;
 
   // keep track of event subscription
   private eventServiceSubscription: Subscription;

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { Subscription } from 'rxjs/Subscription';
@@ -13,29 +13,19 @@ import { Event } from '../../event';
   templateUrl: './origin-pin.component.html',
   styleUrls: ['./origin-pin.component.scss']
 })
-export class OriginPinComponent implements OnDestroy, OnInit {
+export class OriginPinComponent implements OnChanges {
   @Input() contributors: any;
-  @Input() event: any;
+  @Input() event: Event;
 
-  title = 'Origin';
   product: any;
-
-  // keep track of event subscription
-  private eventServiceSubscription: Subscription;
+  title = 'Origin';
 
   constructor(
     public eventService: EventService,
     public formatterService: FormatterService
   ) { }
 
-  ngOnInit () {
-    this.eventServiceSubscription = this.eventService.event$.subscribe(
-        (event: Event) => {
-      this.product = event.getProduct('origin');
-    });
-  }
-
-  ngOnDestroy () {
-    this.eventServiceSubscription.unsubscribe();
+  ngOnChanges() {
+    this.product = this.event.getProduct('origin');
   }
 }

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnInit } from '@angular/core';
+
+import { Subscription } from 'rxjs/Subscription';
+
+import { DateTimePipe } from '../../product-page/date-time.pipe';
+import { EventService } from '../../event.service';
+import { Event } from '../../event';
+
+@Component({
+  selector: 'app-origin-pin',
+  templateUrl: './origin-pin.component.html',
+  styleUrls: ['./origin-pin.component.css']
+})
+export class OriginPinComponent implements OnInit {
+  title: string = 'Title';
+  content: string = 'Content ...';
+  actions: string = 'Press Me';
+  footer: string = 'Footer';
+  product: any;
+
+  // keep track of event subscription
+  private eventServiceSubscription: Subscription;
+
+  constructor(
+    public eventService: EventService
+  ) { }
+
+  ngOnInit () {
+    this.eventServiceSubscription = this.eventService.event$.subscribe(
+        (event: Event) => {
+      this.product = event.getProduct('origin');
+    });
+  }
+
+  ngOnDestroy () {
+    this.eventServiceSubscription.unsubscribe();
+  }
+
+  toJson (data: any): string {
+    return JSON.stringify(data, null, 2);
+  }
+}

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -1,28 +1,27 @@
 import { Component, OnInit } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 import { Subscription } from 'rxjs/Subscription';
 
-import { DateTimePipe } from '../../product-page/date-time.pipe';
 import { EventService } from '../../event.service';
+import { FormatterService } from '../../formatter.service';
+
 import { Event } from '../../event';
 
 @Component({
   selector: 'app-origin-pin',
   templateUrl: './origin-pin.component.html',
-  styleUrls: ['./origin-pin.component.css']
+  styleUrls: ['./origin-pin.component.scss']
 })
 export class OriginPinComponent implements OnInit {
-  title: string = 'Title';
-  content: string = 'Content ...';
-  actions: string = 'Press Me';
-  footer: string = 'Footer';
-  product: any;
+  title: string = 'Origin';
 
   // keep track of event subscription
   private eventServiceSubscription: Subscription;
 
   constructor(
-    public eventService: EventService
+    public eventService: EventService,
+    public formatterService: FormatterService
   ) { }
 
   ngOnInit () {

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { Subscription } from 'rxjs/Subscription';
@@ -13,11 +13,11 @@ import { Event } from '../../event';
   templateUrl: './origin-pin.component.html',
   styleUrls: ['./origin-pin.component.scss']
 })
-export class OriginPinComponent implements OnInit {
+export class OriginPinComponent implements OnDestroy, OnInit {
   @Input() contributors: any;
   @Input() event: any;
 
-  title: string = 'Origin';
+  title = 'Origin';
   product: any;
 
   // keep track of event subscription
@@ -37,9 +37,5 @@ export class OriginPinComponent implements OnInit {
 
   ngOnDestroy () {
     this.eventServiceSubscription.unsubscribe();
-  }
-
-  toJson (data: any): string {
-    return JSON.stringify(data, null, 2);
   }
 }

--- a/src/app/formatter.service.ts
+++ b/src/app/formatter.service.ts
@@ -83,12 +83,14 @@ export class FormatterService {
    *
    * @return {String}
    */
-  depth (depth: number, units?: string, error?: number) {
+  depth (depth: number, units?: string, precision?: number, error?: number) {
     let number,
         uncertainty;
 
-    number = this.number(depth, this.depthDecimals, this.empty, units);
-    uncertainty = this.uncertainty(error, this.depthDecimals, '');
+    precision = precision ? precision : this.depthDecimals;
+    number = this.number(depth, precision, this.empty, units);
+    uncertainty = this.uncertainty(error, precision, '');
+
     return number + uncertainty;
   }
 

--- a/src/app/formatter.service.ts
+++ b/src/app/formatter.service.ts
@@ -83,14 +83,12 @@ export class FormatterService {
    *
    * @return {String}
    */
-  depth (depth: number, units?: string, precision?: number, error?: number) {
+  depth (depth: number, units?: string, error?: number) {
     let number,
         uncertainty;
 
-    precision = precision ? precision : this.depthDecimals;
-    number = this.number(depth, precision, this.empty, units);
-    uncertainty = this.uncertainty(error, precision, '');
-
+    number = this.number(depth, this.depthDecimals, this.empty, units);
+    uncertainty = this.uncertainty(error, this.depthDecimals, '');
     return number + uncertainty;
   }
 

--- a/src/app/product-page/product-page.module.ts
+++ b/src/app/product-page/product-page.module.ts
@@ -31,7 +31,8 @@ import { FileSizePipe } from './file-size.pipe';
     FileSizePipe
   ],
   exports: [
-    ProductPageComponent
+    ProductPageComponent,
+    DateTimePipe
   ]
 })
 export class ProductPageModule { }

--- a/src/app/product-page/product-page.module.ts
+++ b/src/app/product-page/product-page.module.ts
@@ -31,6 +31,7 @@ import { FileSizePipe } from './file-size.pipe';
     FileSizePipe
   ],
   exports: [
+    ContributorListPipe,
     ProductPageComponent,
     DateTimePipe
   ]


### PR DESCRIPTION
fixes #756 

I changed the layout a bit. I moved the "contributed by" section to the top so that it is part of the mat-card "subtitle", I think this works better so that we can put our call-to-action at the bottom. The whole pin is still clickable, but this follows the material design layout.

<img width="261" alt="screen shot 2018-02-26 at 9 27 23 am" src="https://user-images.githubusercontent.com/1932750/36681981-4a138c44-1ad7-11e8-8a18-8fb3fcb4508c.png">
