### PR TITLE
Origin Pin Fixes

### DIFF
--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -1,10 +1,10 @@
 <ng-container *ngIf="eventService.event$ | async; let event">
   <ul class="executive-summary-pins">
     <li class="executive-summary-pin">
-      <app-origin-pin class="pin-view"
+      <origin-pin class="pin-view"
           [contributors]="contributorService.contributors$ | async"
           [event]="event">
-      </app-origin-pin>
+      </origin-pin>
     </li>
     <li class="executive-summary-pin">
       <app-regional-pin class="pin-view"

--- a/src/app/executive/executive/executive.component.spec.ts
+++ b/src/app/executive/executive/executive.component.spec.ts
@@ -17,8 +17,8 @@ describe('ExecutiveComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         ExecutiveComponent,
-        MockComponent({ selector: 'app-origin-pin', inputs: ['event', 'contributors']}),
         MockComponent({ selector: 'app-regional-pin', inputs: ['event', 'contributors']}),
+        MockComponent({ selector: 'origin-pin', inputs: ['event', 'contributors']}),
         MockComponent({ selector: 'shared-link-product', inputs: ['product']}),
         MockComponent({ selector: 'shared-text-product', inputs: ['product']})
       ],

--- a/src/app/executive/origin-pin/origin-pin.component.html
+++ b/src/app/executive/origin-pin/origin-pin.component.html
@@ -10,16 +10,16 @@
     <mat-card-content>
       <dl>
         <dt>Review Status</dt>
-        <dd>{{ product.properties['review-status'].toUpperCase() }}</dd>
+        <dd [innerHTML]="this.formatterService.reviewStatus(product.properties['review-status'])"></dd>
 
         <dt>Magnitude</dt>
-        <dd>{{ product.properties.magnitude }} {{ product.properties['magnitude-type'] }}</dd>
+        <dd [innerHTML]="this.formatterService.magnitude(product.properties.magnitude, product.properties['magnitude-type'])"></dd>
 
         <dt>Depth</dt>
-        <dd>{{ this.formatterService.depth(product.properties.depth, 'km') }}</dd>
+        <dd [innerHTML]="this.formatterService.depth(product.properties.depth, 'km')"></dd>
 
         <dt>Time</dt>
-        <dd>{{ product.properties.eventtime | date:"yyyy-MM-dd HH:mm:ss":"UTC" }} (UTC)</dd>
+        <dd [innerHTML]="this.formatterService.dateTime(product.properties.eventtime)"></dd>
       </dl>
     </mat-card-content>
     <mat-card-actions>

--- a/src/app/executive/origin-pin/origin-pin.component.spec.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.spec.ts
@@ -9,20 +9,14 @@ import {
 import { MockPipe } from '../../mock-pipe';
 
 import { OriginPinComponent } from './origin-pin.component';
-
-import { EventService } from '../../event.service';
 import { FormatterService } from '../../formatter.service';
+import { Event } from '../../event';
 
 describe('OriginPinComponent', () => {
   let component: OriginPinComponent;
   let fixture: ComponentFixture<OriginPinComponent>;
 
   beforeEach(async(() => {
-    const eventServiceStub = {
-      getEvent: jasmine.createSpy('eventService::getEvent'),
-      getProduct: jasmine.createSpy('eventService::getProduct')
-    };
-
     TestBed.configureTestingModule({
       declarations: [
         OriginPinComponent,
@@ -37,7 +31,6 @@ describe('OriginPinComponent', () => {
         RouterModule
       ],
       providers: [
-        { provide: EventService, useValue: eventServiceStub },
         { provide: FormatterService, useValue: {} }
       ]
     })
@@ -53,4 +46,27 @@ describe('OriginPinComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('ngOnChanges', () => {
+    it('should fetch/set the origin product', () => {
+      let event: Event,
+          product,
+          spy;
+
+      event = new Event({});
+      product = { id: 1 };
+
+      // spy on event object
+      component.event = event;
+      spy = spyOn(component.event, 'getProduct').and.returnValue(product);
+
+      // trigger ngOnChanges
+      component.ngOnChanges();
+
+      // check component's product value
+      expect(spy).toHaveBeenCalled();
+      expect(component.product).toEqual(product);
+    });
+  });
+
 });

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -9,7 +9,7 @@ import { FormatterService } from '../../formatter.service';
 import { Event } from '../../event';
 
 @Component({
-  selector: 'app-origin-pin',
+  selector: 'origin-pin',
   templateUrl: './origin-pin.component.html',
   styleUrls: ['./origin-pin.component.scss']
 })

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -3,7 +3,6 @@ import { RouterLink } from '@angular/router';
 
 import { Subscription } from 'rxjs/Subscription';
 
-import { EventService } from '../../event.service';
 import { FormatterService } from '../../formatter.service';
 
 import { Event } from '../../event';
@@ -19,10 +18,8 @@ export class OriginPinComponent implements OnChanges {
 
   product: any;
   title = 'Origin';
-  testDate = new Date(1234567891011);
 
   constructor(
-    public eventService: EventService,
     public formatterService: FormatterService
   ) { }
 

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -19,6 +19,7 @@ export class OriginPinComponent implements OnChanges {
 
   product: any;
   title = 'Origin';
+  testDate = new Date(1234567891011);
 
   constructor(
     public eventService: EventService,

--- a/src/app/formatter.service.ts
+++ b/src/app/formatter.service.ts
@@ -46,8 +46,8 @@ export class FormatterService {
   /**
    * Format a date and time.
    *
-   * @param stamp {Date}
-   *     Date or millisecond epoch timstamp to format.
+   * @param stamp {value}
+   *     Date, ISO8601 formatted string, or millisecond epoch timstamp.
    * @param minutesOffset {Number} Optional, default 0
    *     UTC offset in minutes. 0 for UTC.
    * @param includeMilliseconds {Boolean} Optional, default false
@@ -55,11 +55,17 @@ export class FormatterService {
    *
    * @return {String}
    */
-  dateTime (date: Date, minutesOffset = 0, includeMilliseconds = false) {
+  dateTime (date: any, minutesOffset = 0, includeMilliseconds = false) {
     let milliOffset;
 
     if (date === null || typeof date === 'undefined') {
       return this.empty;
+    }
+
+    if (typeof date === 'string') {
+      date = new Date(date);
+    } else if (typeof date === 'number') {
+      date = new Date(date);
     }
 
     if (minutesOffset) {
@@ -164,6 +170,24 @@ export class FormatterService {
   }
 
   /**
+   * Format a magnitude and magnitude type.
+   *
+   * @param value {Number}
+   *        Magnitude value to format.
+   * @param type {String}
+   *        Magnitude type to format with magnitude value (i.e. mw, mww, mb)
+   *
+   * @return {String}
+   */
+  magnitude (value: number, type: string) {
+    if (!value) {
+      return this.empty;
+    }
+
+    return this.number(value) + ' ' + type;
+  }
+
+  /**
    * Format a number.
    *
    * @param value {Number}
@@ -198,6 +222,22 @@ export class FormatterService {
     }
 
     return result;
+  }
+
+  /**
+   * Format the review status of a product
+   *
+   * @param status {String}
+   *        Review status to format. ("reviewed", "official")
+   *
+   * @return {String}
+   */
+  reviewStatus (status: string): string {
+    if (!status || status === '') {
+      return this.empty;
+    }
+
+    return status.toUpperCase();
   }
 
   /**


### PR DESCRIPTION
fixes #756 

Completed:
- Change `app-origin-pin` selector to simply `origin-pin`.
- Be sure to capture `null` case for product properties and use `&ndash;` appropriately.
  - Review Status
  - Magnitude (and Type)
  - Time
- Prefer `formatterService.dateTime` over built-in `date` pipe
- Probably use `formatterService` for other outputs (which captures `null` values already)
- Need tests for `ngOnChanges` method

Not Completed:
- Thoughts on an "attribution" component rather than a repeated design pattern?
- Maybe abstract out some of the common implementation (structure, styles, etc...) to a generic pin component ? Maybe this can be done as part of the next pin.

It seems like each part of the pin components is to unique to get much use out of an abstracted pin component. I think that an attribution component or pipe would work. 