### PR TITLE
Update Origin-Pin

### DIFF
--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -1,8 +1,9 @@
 <ng-container *ngIf="eventService.event$ | async; let event">
   <ul class="executive-summary-pins">
     <li class="executive-summary-pin">
-      <origin-pin class="pin-view" [event]="event">
-      </origin-pin>
+      <executive-origin-pin class="pin-view"
+          [event]="event">
+      </executive-origin-pin>
     </li>
     <li class="executive-summary-pin">
       <app-regional-pin class="pin-view" [event]="event">

--- a/src/app/executive/executive/executive.component.spec.ts
+++ b/src/app/executive/executive/executive.component.spec.ts
@@ -17,8 +17,8 @@ describe('ExecutiveComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         ExecutiveComponent,
-        MockComponent({ selector: 'app-regional-pin', inputs: ['event']}),
-        MockComponent({ selector: 'origin-pin', inputs: ['event']}),
+        MockComponent({ selector: 'app-regional-pin', inputs: ['event', 'contributors']}),
+        MockComponent({ selector: 'executive-origin-pin', inputs: ['event', 'contributors']}),
         MockComponent({ selector: 'shared-link-product', inputs: ['product']}),
         MockComponent({ selector: 'shared-text-product', inputs: ['product']})
       ],

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -8,7 +8,7 @@ import { FormatterService } from '../../formatter.service';
 import { Event } from '../../event';
 
 @Component({
-  selector: 'origin-pin',
+  selector: 'executive-origin-pin',
   templateUrl: './origin-pin.component.html',
   styleUrls: ['./origin-pin.component.scss']
 })

--- a/src/app/formatter.service.ts
+++ b/src/app/formatter.service.ts
@@ -201,6 +201,7 @@ export class FormatterService {
     return `${result}&deg;${lngDir}`;
   }
 
+
   /**
    * Format a magnitude and magnitude type.
    *

--- a/src/app/formatter.service.ts
+++ b/src/app/formatter.service.ts
@@ -240,7 +240,7 @@ export class FormatterService {
         result;
 
     if (!value && value !== 0) {
-      return empty;
+      return this.empty;
     }
 
     if (typeof decimals === 'number') {

--- a/src/app/formatter.service.ts
+++ b/src/app/formatter.service.ts
@@ -65,7 +65,7 @@ export class FormatterService {
   /**
    * Format a date and time.
    *
-   * @param stamp {value}
+   * @param date {Number|String|Date}
    *     Date, ISO8601 formatted string, or millisecond epoch timstamp.
    * @param minutesOffset {Number} Optional, default 0
    *     UTC offset in minutes. 0 for UTC.
@@ -81,9 +81,7 @@ export class FormatterService {
       return this.empty;
     }
 
-    if (typeof date === 'string') {
-      date = new Date(date);
-    } else if (typeof date === 'number') {
+    if (!(date instanceof Date)) {
       date = new Date(date);
     }
 

--- a/src/app/formatter.service.ts
+++ b/src/app/formatter.service.ts
@@ -201,7 +201,6 @@ export class FormatterService {
     return `${result}&deg;${lngDir}`;
   }
 
-
   /**
    * Format a magnitude and magnitude type.
    *

--- a/src/app/formatter.service.ts
+++ b/src/app/formatter.service.ts
@@ -266,7 +266,7 @@ export class FormatterService {
    * @return {String}
    */
   reviewStatus (status: string): string {
-    if (!status || status === '') {
+    if (!status) {
       return this.empty;
     }
 

--- a/src/app/formatter.service.ts
+++ b/src/app/formatter.service.ts
@@ -239,7 +239,7 @@ export class FormatterService {
         result;
 
     if (!value && value !== 0) {
-      return this.empty;
+      return empty;
     }
 
     if (typeof decimals === 'number') {


### PR DESCRIPTION
fixes #756 

In response to @emartinez-usgs comments:

- Should call `date` and `time` methods separately with `<br/>` in between.

**I think we have plenty of room, and the time will wrap if the card width is limited**

- Prefer: `date: number|string|Date`

**es lint does not like this, even though Date() should accept a string or number**
```
Argument of type 'string | number' is not assignable to parameter of type 'string'.
  Type 'number' is not assignable to type 'string'
```

I changed the rest:
- Maybe simply `if (!(date instanceof Date)) { ... `
- Documentation: `stamp` is not a parameter for the `date` method. `{value}` should indicate acceptable data types.
- `magnitude` method should check for `value === 0` and not use `this.empty`
- Empty strings evaluate to false, so `!status || status === ''` is redundant
- With more thought, I think `origin-pin` selector should actually be `executive-origin-pin`. My bad.