### PR TITLE
Update Region-Info pin

### DIFF
--- a/src/app/event-page/event-page.module.ts
+++ b/src/app/event-page/event-page.module.ts
@@ -42,6 +42,7 @@ import { NavigationComponent } from './navigation/navigation.component';
     NavigationComponent
   ],
   exports: [
+    ContributorListPipe,
     EventPageComponent
   ],
 })

--- a/src/app/executive/basic-pin/basic-pin.component.html
+++ b/src/app/executive/basic-pin/basic-pin.component.html
@@ -18,7 +18,9 @@
       </ng-container>
       <ng-template #noSubtitle>
         Contributed by
-        <span [innerHTML]="product | contributorList:event:contributors"></span>
+        <shared-attribution
+          [sourceCode]="product?.properties['origin-source'] || product?.source"
+        ></shared-attribution>
       </ng-template>
     </mat-card-subtitle>
 

--- a/src/app/executive/basic-pin/basic-pin.component.html
+++ b/src/app/executive/basic-pin/basic-pin.component.html
@@ -1,0 +1,45 @@
+  <!-- Basic Pin - material card -->
+  <mat-card [routerLink]="link">
+
+    <!-- Title -->
+    <mat-card-title>
+      <ng-container *ngIf="title; else noTitle">
+        {{ title }}
+      </ng-container>
+      <ng-template #noTitle>
+        <ng-content select="[card-title]"></ng-content>
+      </ng-template>
+    </mat-card-title>
+
+    <!-- Subtitle -->
+    <mat-card-subtitle>
+      <ng-container *ngIf="subtitle; else noSubtitle">
+        {{ subtitle }}
+      </ng-container>
+      <ng-template #noSubtitle>
+        Contributed by
+        <span [innerHTML]="product | contributorList:event:contributors"></span>
+      </ng-template>
+    </mat-card-subtitle>
+
+    <!-- Image -->
+    <ng-content select="[card-image]"></ng-content>
+
+    <!-- Content -->
+    <mat-card-content>
+      <ng-content select="[card-content]"></ng-content>
+    </mat-card-content>
+
+    <!-- Actions -->
+    <mat-card-actions>
+      <ng-container *ngIf="action; else noAction">
+        <a mat-button color="primary" [routerLink]="action">
+          View {{ title }}
+        </a>
+      </ng-container>
+      <ng-template #noAction>
+        <ng-content select="[card-action]"></ng-content>
+      </ng-template>
+    </mat-card-actions>
+
+  </mat-card>

--- a/src/app/executive/basic-pin/basic-pin.component.spec.ts
+++ b/src/app/executive/basic-pin/basic-pin.component.spec.ts
@@ -1,14 +1,50 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatDividerModule,
+  MatListModule
+} from '@angular/material';
+import { MockPipe } from '../../mock-pipe';
+import { of } from 'rxjs/observable/of';
 
 import { BasicPinComponent } from './basic-pin.component';
+import { ContributorService } from '../../contributor.service';
+import { Event } from '../../event';
+import { EventService } from '../../event.service';
 
 describe('BasicPinComponent', () => {
   let component: BasicPinComponent;
   let fixture: ComponentFixture<BasicPinComponent>;
 
   beforeEach(async(() => {
+    const eventServiceStub = {
+      event$: of(new Event({})),
+      getProduct: jasmine.createSpy('eventService::getProduct')
+    };
+
+    const contributorServiceStub = {
+      contributors$: of({})
+    };
+
     TestBed.configureTestingModule({
-      declarations: [ BasicPinComponent ]
+      declarations: [
+        BasicPinComponent,
+
+        MockPipe('contributorList')
+      ],
+      imports: [
+        MatListModule,
+        MatButtonModule,
+        MatCardModule,
+        MatDividerModule,
+        RouterTestingModule
+      ],
+      providers: [
+        { provide: EventService, useValue: eventServiceStub },
+        { provide: ContributorService, useValue: contributorServiceStub }
+      ]
     })
     .compileComponents();
   }));

--- a/src/app/executive/basic-pin/basic-pin.component.spec.ts
+++ b/src/app/executive/basic-pin/basic-pin.component.spec.ts
@@ -6,6 +6,7 @@ import {
   MatDividerModule,
   MatListModule
 } from '@angular/material';
+import { MockComponent } from 'ng2-mock-component';
 import { MockPipe } from '../../mock-pipe';
 import { of } from 'rxjs/observable/of';
 
@@ -32,6 +33,7 @@ describe('BasicPinComponent', () => {
       declarations: [
         BasicPinComponent,
 
+        MockComponent({selector: 'shared-attribution', inputs: ['sourceCode']}),
         MockPipe('contributorList')
       ],
       imports: [

--- a/src/app/executive/basic-pin/basic-pin.component.spec.ts
+++ b/src/app/executive/basic-pin/basic-pin.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BasicPinComponent } from './basic-pin.component';
+
+describe('BasicPinComponent', () => {
+  let component: BasicPinComponent;
+  let fixture: ComponentFixture<BasicPinComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ BasicPinComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BasicPinComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/executive/basic-pin/basic-pin.component.ts
+++ b/src/app/executive/basic-pin/basic-pin.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { ContributorService } from '../../contributor.service';
+import { Event } from '../../event';
+import { EventService } from '../../event.service';
+
+@Component({
+  selector: 'basic-pin',
+  templateUrl: './basic-pin.component.html',
+  styleUrls: ['./basic-pin.component.css']
+})
+export class BasicPinComponent implements OnInit {
+  @Input() action; // router link for action button
+  @Input() link; // router link for entire card action
+  @Input() subtitle; // text for subtitle
+  @Input() title; // text for title
+  @Input() type; // type of product
+
+  public contributors;
+  public contributorSubscription;
+  public event;
+  public eventSubscription;
+  public product;
+
+  constructor (
+    public eventService: EventService,
+    public contributorService: ContributorService
+  ) { }
+
+  ngOnInit () {
+    this.contributorSubscription = this.contributorService.contributors$.subscribe((contributors) => {
+      this.contributors = contributors;
+    });
+    this.eventSubscription = this.eventService.event$.subscribe((event) => {
+      this.event = event;
+      this.product = event.getProduct(this.type);
+    });
+  }
+
+  ngOnDestroy () {
+    this.contributorSubscription.unsubscribe();
+    this.eventSubscription.unsubscribe();
+  }
+}

--- a/src/app/executive/basic-pin/basic-pin.component.ts
+++ b/src/app/executive/basic-pin/basic-pin.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { ContributorService } from '../../contributor.service';
@@ -10,7 +10,7 @@ import { EventService } from '../../event.service';
   templateUrl: './basic-pin.component.html',
   styleUrls: ['./basic-pin.component.css']
 })
-export class BasicPinComponent implements OnInit {
+export class BasicPinComponent implements OnDestroy, OnInit {
   @Input() action; // router link for action button
   @Input() link; // router link for entire card action
   @Input() subtitle; // text for subtitle

--- a/src/app/executive/basic-pin/basic-pin.component.ts
+++ b/src/app/executive/basic-pin/basic-pin.component.ts
@@ -1,45 +1,39 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
-import { ContributorService } from '../../contributor.service';
 import { Event } from '../../event';
-import { EventService } from '../../event.service';
+
 
 @Component({
   selector: 'basic-pin',
   templateUrl: './basic-pin.component.html',
   styleUrls: ['./basic-pin.component.css']
 })
-export class BasicPinComponent implements OnDestroy, OnInit {
+export class BasicPinComponent {
+
+  private _event: Event;
+  public product;
+
   @Input() action; // router link for action button
   @Input() link; // router link for entire card action
   @Input() subtitle; // text for subtitle
   @Input() title; // text for title
   @Input() type; // type of product
 
-  public contributors;
-  public contributorSubscription;
-  public event;
-  public eventSubscription;
-  public product;
-
-  constructor (
-    public eventService: EventService,
-    public contributorService: ContributorService
-  ) { }
-
-  ngOnInit () {
-    this.contributorSubscription = this.contributorService.contributors$.subscribe((contributors) => {
-      this.contributors = contributors;
-    });
-    this.eventSubscription = this.eventService.event$.subscribe((event) => {
-      this.event = event;
-      this.product = event.getProduct(this.type);
-    });
+  // event passed from executive summary
+  @Input() set event (event: Event) {
+    this._event = event;
+    if (event) {
+      this.product = event.getProduct('origin');
+    } else {
+      this.product = null;
+    }
   }
 
-  ngOnDestroy () {
-    this.contributorSubscription.unsubscribe();
-    this.eventSubscription.unsubscribe();
+  get event () {
+    return this._event;
   }
+
+  constructor () { }
+
 }

--- a/src/app/executive/executive.module.ts
+++ b/src/app/executive/executive.module.ts
@@ -16,6 +16,7 @@ import { RegionalPinComponent } from './regional-pin/regional-pin.component';
 import { EventPageModule } from '../event-page/event-page.module';
 import { ProductPageModule } from '../product-page/product-page.module';
 import { SharedModule } from '../shared/shared.module';
+import { BasicPinComponent } from './basic-pin/basic-pin.component';
 
 @NgModule({
   imports: [
@@ -32,7 +33,8 @@ import { SharedModule } from '../shared/shared.module';
   declarations: [
     ExecutiveComponent,
     OriginPinComponent,
-    RegionalPinComponent
+    RegionalPinComponent,
+    BasicPinComponent
   ]
 })
 export class ExecutiveModule { }

--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -7,7 +7,6 @@
     </li>
     <li class="executive-summary-pin">
       <region-info-pin class="pin-view"
-          [contributors]="contributorService.contributors$ | async"
           [event]="event">
       </region-info-pin>
     </li>

--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -6,8 +6,10 @@
       </executive-origin-pin>
     </li>
     <li class="executive-summary-pin">
-      <app-regional-pin class="pin-view" [event]="event">
-      </app-regional-pin>
+      <region-info-pin class="pin-view"
+          [contributors]="contributorService.contributors$ | async"
+          [event]="event">
+      </region-info-pin>
     </li>
   </ul>
   <shared-text-product

--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -6,9 +6,9 @@
       </executive-origin-pin>
     </li>
     <li class="executive-summary-pin">
-      <region-info-pin class="pin-view"
+      <executive-region-info-pin class="pin-view"
           [event]="event">
-      </region-info-pin>
+      </executive-region-info-pin>
     </li>
   </ul>
   <shared-text-product

--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -15,7 +15,6 @@
       *ngFor="let product of event.getProducts('general-text')"
       [product]="product">
   </shared-text-product>
-
   <ng-container *ngIf="event.hasProducts('general-link')">
     <h3>For More Information</h3>
     <ul>

--- a/src/app/executive/executive/executive.component.spec.ts
+++ b/src/app/executive/executive/executive.component.spec.ts
@@ -18,7 +18,7 @@ describe('ExecutiveComponent', () => {
       declarations: [
         ExecutiveComponent,
         MockComponent({ selector: 'executive-origin-pin', inputs: ['event', 'contributors']}),
-        MockComponent({ selector: 'region-info-pin', inputs: ['event', 'contributors']}),
+        MockComponent({ selector: 'executive-region-info-pin', inputs: ['event', 'contributors']}),
         MockComponent({ selector: 'shared-link-product', inputs: ['product']}),
         MockComponent({ selector: 'shared-text-product', inputs: ['product']})
       ],

--- a/src/app/executive/executive/executive.component.spec.ts
+++ b/src/app/executive/executive/executive.component.spec.ts
@@ -17,8 +17,8 @@ describe('ExecutiveComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         ExecutiveComponent,
-        MockComponent({ selector: 'app-regional-pin', inputs: ['event', 'contributors']}),
         MockComponent({ selector: 'executive-origin-pin', inputs: ['event', 'contributors']}),
+        MockComponent({ selector: 'region-info-pin', inputs: ['event', 'contributors']}),
         MockComponent({ selector: 'shared-link-product', inputs: ['product']}),
         MockComponent({ selector: 'shared-text-product', inputs: ['product']})
       ],

--- a/src/app/executive/executive/executive.component.ts
+++ b/src/app/executive/executive/executive.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { EventService } from '../../event.service';
-import { ContributorService } from '../../contributor.service';
 
 @Component({
   selector: 'app-executive',
@@ -11,8 +10,7 @@ import { ContributorService } from '../../contributor.service';
 export class ExecutiveComponent implements OnInit {
 
   constructor (
-    public eventService: EventService,
-    public contributorService: ContributorService
+    public eventService: EventService
   ) { }
 
   ngOnInit () {

--- a/src/app/executive/origin-pin/origin-pin.component.html
+++ b/src/app/executive/origin-pin/origin-pin.component.html
@@ -1,29 +1,22 @@
 <ng-container *ngIf="product">
-  <mat-card [routerLink]="'../origin'">
-    <mat-card-title>
-      {{ title }}
-    </mat-card-title>
-    <mat-card-subtitle>
-      Contributed by
-      <shared-product-attribution [product]="product"></shared-product-attribution>
-    </mat-card-subtitle>
-    <mat-card-content>
-      <dl>
-        <dt>Review Status</dt>
-        <dd [innerHTML]="this.formatterService.reviewStatus(product.properties['review-status'])"></dd>
+  <basic-pin
+      [title]=title
+      [link]=link
+      [action]=link
+      [type]=type>
+    <!-- pin content -->
+    <dl card-content>
+      <dt>Review Status</dt>
+      <dd>{{ product.properties['review-status'].toUpperCase() }}</dd>
 
-        <dt>Magnitude</dt>
-        <dd [innerHTML]="this.formatterService.magnitude(product.properties.magnitude, product.properties['magnitude-type'])"></dd>
+      <dt>Magnitude</dt>
+      <dd>{{ product.properties.magnitude }} {{ product.properties['magnitude-type'] }}</dd>
 
-        <dt>Depth</dt>
-        <dd [innerHTML]="this.formatterService.depth(product.properties.depth, 'km')"></dd>
+      <dt>Depth</dt>
+      <dd>{{ this.formatterService.depth(product.properties.depth, 'km') }}</dd>
 
-        <dt>Time</dt>
-        <dd [innerHTML]="this.formatterService.dateTime(product.properties.eventtime)"></dd>
-      </dl>
-    </mat-card-content>
-    <mat-card-actions>
-      <a mat-button color="primary" [routerLink]="'../origin'">View Origin Details</a>
-    </mat-card-actions>
-  </mat-card>
+      <dt>Time</dt>
+      <dd>{{ product.properties.eventtime | date:"yyyy-MM-dd HH:mm:ss":"UTC" }} (UTC)</dd>
+    </dl>
+  </basic-pin>
 </ng-container>

--- a/src/app/executive/origin-pin/origin-pin.component.html
+++ b/src/app/executive/origin-pin/origin-pin.component.html
@@ -1,8 +1,9 @@
 <ng-container *ngIf="product">
   <basic-pin
-      [title]=title
-      [link]=link
       [action]=link
+      [event]=event
+      [link]=link
+      [title]=title
       [type]=type>
     <!-- pin content -->
     <dl card-content>

--- a/src/app/executive/origin-pin/origin-pin.component.spec.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.spec.ts
@@ -1,16 +1,17 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import {
   MatButtonModule,
   MatCardModule,
   MatDividerModule,
   MatListModule
 } from '@angular/material';
-
-import { OriginPinComponent } from './origin-pin.component';
-import { FormatterService } from '../../formatter.service';
-import { Event } from '../../event';
 import { MockComponent } from 'ng2-mock-component';
+
+import { Event } from '../../event';
+import { FormatterService } from '../../formatter.service';
+import { OriginPinComponent } from './origin-pin.component';
+
 
 describe('OriginPinComponent', () => {
   let component: OriginPinComponent;
@@ -21,14 +22,20 @@ describe('OriginPinComponent', () => {
       declarations: [
         OriginPinComponent,
 
-        MockComponent({selector: 'shared-product-attribution', inputs: ['product']})
+        MockComponent({selector: 'shared-product-attribution', inputs: ['product']}),
+        MockComponent({
+          selector: 'basic-pin',
+          inputs: [
+            'action',
+            'link',
+            'subtitle',
+            'title',
+            'type'
+          ]
+        })
       ],
       imports: [
-        MatListModule,
-        MatButtonModule,
-        MatCardModule,
-        MatDividerModule,
-        RouterModule
+        RouterTestingModule
       ],
       providers: [
         { provide: FormatterService, useValue: {} }

--- a/src/app/executive/origin-pin/origin-pin.component.spec.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.spec.ts
@@ -27,6 +27,7 @@ describe('OriginPinComponent', () => {
           selector: 'basic-pin',
           inputs: [
             'action',
+            'event',
             'link',
             'subtitle',
             'title',

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -1,21 +1,21 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
-import { Subscription } from 'rxjs/Subscription';
-
-import { FormatterService } from '../../formatter.service';
-
 import { Event } from '../../event';
+import { FormatterService } from '../../formatter.service';
 
 @Component({
   selector: 'executive-origin-pin',
   templateUrl: './origin-pin.component.html',
   styleUrls: ['./origin-pin.component.scss']
 })
+
 export class OriginPinComponent {
 
-  public product: any = null;
+  public link = '../origin';
+  public product: any;
   public title = 'Origin';
+  public type = 'origin';
 
   private _event: Event;
 
@@ -31,6 +31,7 @@ export class OriginPinComponent {
   get event () {
     return this._event;
   }
+
 
   constructor(
     public formatterService: FormatterService

--- a/src/app/executive/origin-pin/origin-pin.component.ts
+++ b/src/app/executive/origin-pin/origin-pin.component.ts
@@ -12,13 +12,13 @@ import { FormatterService } from '../../formatter.service';
 
 export class OriginPinComponent {
 
+  private _event: Event;
   public link = '../origin';
   public product: any;
   public title = 'Origin';
   public type = 'origin';
 
-  private _event: Event;
-
+  // event passed from executive summary
   @Input() set event (event: Event) {
     this._event = event;
     if (event) {
@@ -31,7 +31,6 @@ export class OriginPinComponent {
   get event () {
     return this._event;
   }
-
 
   constructor(
     public formatterService: FormatterService

--- a/src/app/executive/regional-pin/regional-pin.component.html
+++ b/src/app/executive/regional-pin/regional-pin.component.html
@@ -1,9 +1,7 @@
-<ng-container>
-  <basic-pin
-      [title]=title
-      [link]=link
-      [action]=link
-      [type]=type>
-    <div card-image mat-card-image id="region-info-map"></div>
-  </basic-pin>
-</ng-container>
+<basic-pin
+    [title]=title
+    [link]=link
+    [action]=link
+    [type]=type>
+  <div card-image mat-card-image id="region-info-map"></div>
+</basic-pin>

--- a/src/app/executive/regional-pin/regional-pin.component.html
+++ b/src/app/executive/regional-pin/regional-pin.component.html
@@ -1,7 +1,8 @@
 <basic-pin
-    [title]=title
-    [link]=link
     [action]=link
+    [event]=event
+    [link]=link
+    [title]=title
     [type]=type>
   <div card-image mat-card-image id="region-info-map"></div>
 </basic-pin>

--- a/src/app/executive/regional-pin/regional-pin.component.html
+++ b/src/app/executive/regional-pin/regional-pin.component.html
@@ -1,17 +1,9 @@
 <ng-container>
-  <mat-card [routerLink]="'../region-info'">
-    <mat-card-title>
-      {{ title }}
-    </mat-card-title>
-    <mat-card-subtitle>
-      Contributed by
-      <shared-product-attribution [product]="product"></shared-product-attribution>
-    </mat-card-subtitle>
-    <div mat-card-image id="region-info-map"></div>
-    <mat-card-actions>
-      <a mat-button color="primary" [routerLink]="'../region-info'">
-        View Regional Information
-      </a>
-    </mat-card-actions>
-  </mat-card>
+  <basic-pin
+      [title]=title
+      [link]=link
+      [action]=link
+      [type]=type>
+    <div card-image mat-card-image id="region-info-map"></div>
+  </basic-pin>
 </ng-container>

--- a/src/app/executive/regional-pin/regional-pin.component.spec.ts
+++ b/src/app/executive/regional-pin/regional-pin.component.spec.ts
@@ -1,17 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
-import {
-  MatButtonModule,
-  MatCardModule,
-  MatListModule
-} from '@angular/material';
 
 import * as L from 'leaflet';
 
-import { MockPipe } from '../../mock-pipe';
-import { RegionalPinComponent } from './regional-pin.component';
 import { EventService } from '../../event.service';
 import { MockComponent } from 'ng2-mock-component';
+import { RegionalPinComponent } from './regional-pin.component';
 
 describe('RegionalPinComponent', () => {
   let component: RegionalPinComponent;
@@ -36,14 +31,12 @@ describe('RegionalPinComponent', () => {
         MockComponent({selector: 'shared-product-attribution', inputs: ['product']})
       ],
       imports: [
-        MatListModule,
-        MatButtonModule,
-        MatCardModule,
         RouterTestingModule
       ],
       providers: [
         { provide: EventService, useValue: eventServiceStub }
-      ]
+      ],
+      schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();
   }));
@@ -58,14 +51,9 @@ describe('RegionalPinComponent', () => {
     expect(component).toBeTruthy();
   });
 
-
-
-
-
-
-
   describe('createMap', () => {
     it('should create a map', () => {
+      component.createMap();
       // check map
       expect(component.map).not.toBeNull();
     });
@@ -73,6 +61,7 @@ describe('RegionalPinComponent', () => {
 
   describe('createMarker', () => {
     it('should create a marker', () => {
+      component.createMarker();
       // check marker
       expect(component.marker).not.toBeNull();
     });

--- a/src/app/executive/regional-pin/regional-pin.component.ts
+++ b/src/app/executive/regional-pin/regional-pin.component.ts
@@ -19,6 +19,8 @@ export class RegionalPinComponent implements OnChanges {
 
   title = 'Regional Info';
   product: any;
+  link = '../regional-info';
+  type = 'geoserve';
 
 
   constructor() { }

--- a/src/app/executive/regional-pin/regional-pin.component.ts
+++ b/src/app/executive/regional-pin/regional-pin.component.ts
@@ -3,8 +3,6 @@ import { RouterLink } from '@angular/router';
 
 import * as L from 'leaflet';
 
-import { Event } from '../../event';
-
 
 @Component({
   selector: 'executive-region-info-pin',
@@ -12,16 +10,16 @@ import { Event } from '../../event';
   styleUrls: ['./regional-pin.component.css']
 })
 export class RegionalPinComponent implements OnChanges {
-  @Input() event: any;
 
-  map: L.Map;
-  marker: L.Marker;
+  public map: L.Map;
+  public marker: L.Marker;
 
-  title = 'Regional Info';
-  product: any;
-  link = '../regional-info';
-  type = 'geoserve';
+  public title = 'Regional Info';
+  public product: any;
+  public link = '../regional-info';
+  public type = 'geoserve';
 
+  @Input() event;
 
   constructor() { }
 

--- a/src/app/executive/regional-pin/regional-pin.component.ts
+++ b/src/app/executive/regional-pin/regional-pin.component.ts
@@ -7,7 +7,7 @@ import { Event } from '../../event';
 
 
 @Component({
-  selector: 'app-regional-pin',
+  selector: 'region-info-pin',
   templateUrl: './regional-pin.component.html',
   styleUrls: ['./regional-pin.component.css']
 })

--- a/src/app/executive/regional-pin/regional-pin.component.ts
+++ b/src/app/executive/regional-pin/regional-pin.component.ts
@@ -21,10 +21,9 @@ export class RegionalPinComponent implements OnChanges {
   product: any;
 
 
-  constructor(
-  ) { }
+  constructor() { }
 
-  ngOnChanges(changes) {
+  ngOnChanges (changes) {
     if (!this.event || !this.event.geometry) {
       return;
     }
@@ -49,7 +48,7 @@ export class RegionalPinComponent implements OnChanges {
   /**
    * Create a leaflet map and add the historic seismicity overlay
    */
-  createMap() {
+  createMap () {
     if (this.map) {
       return;
     }
@@ -88,7 +87,7 @@ export class RegionalPinComponent implements OnChanges {
   /**
    * Create the event location marker and add it to the map.
    */
-  createMarker() {
+  createMarker () {
     if (this.marker) {
       return;
     }
@@ -98,7 +97,7 @@ export class RegionalPinComponent implements OnChanges {
     }
 
     // create and add marker to map
-    this.marker = new L.Marker(
+    this.marker = L.marker(
       [ 0, 0 ],
       {
         icon: L.icon({
@@ -118,7 +117,7 @@ export class RegionalPinComponent implements OnChanges {
    * @param {number} longitude
    *        event longitude
    */
-  fitMapBounds(latitude: number, longitude: number) {
+  fitMapBounds (latitude: number, longitude: number) {
     if (!this.map) {
       this.createMap();
     }
@@ -137,7 +136,7 @@ export class RegionalPinComponent implements OnChanges {
    * @param {number} longitude
    *        event longitude
    */
-  updateMarkerLocation(latitude: number, longitude: number) {
+  updateMarkerLocation (latitude: number, longitude: number) {
     // ensure marker is defined,
     // problem with ngOnit not being called when returning to the page
     if (!this.marker) {

--- a/src/app/executive/regional-pin/regional-pin.component.ts
+++ b/src/app/executive/regional-pin/regional-pin.component.ts
@@ -7,7 +7,7 @@ import { Event } from '../../event';
 
 
 @Component({
-  selector: 'region-info-pin',
+  selector: 'executive-region-info-pin',
   templateUrl: './regional-pin.component.html',
   styleUrls: ['./regional-pin.component.css']
 })

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,6 +6,7 @@
 export const environment = {
   production: false,
 
+
   CONTRIBUTOR_SERVICE: 'https://earthquake.usgs.gov/data/comcat/contributor/index.json.php',
   DELETED_EVENT_SERVICE: 'https://earthquake.usgs.gov/fdsnws/event/1/query.geojson?includedeleted=true',
   EVENT_SERVICE: 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/detail',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,7 +6,6 @@
 export const environment = {
   production: false,
 
-
   CONTRIBUTOR_SERVICE: 'https://earthquake.usgs.gov/data/comcat/contributor/index.json.php',
   DELETED_EVENT_SERVICE: 'https://earthquake.usgs.gov/fdsnws/event/1/query.geojson?includedeleted=true',
   EVENT_SERVICE: 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/detail',


### PR DESCRIPTION
fixes #757 

**Addressed**
- Change class name to `region-info-pin`
- Change selector to `region-info-pin`
- Remove `console.log` statements
- Use sub-domains on tileLayer URL.
- Coding standards
  - Use a space between function name and opening parens during function declaration/definition
  - Prefer `L.marker` over `new L.Marker` (unless this doesn't work)
- Why was 'earthquake.usgs.gov' added back to environment config? Is this not fixed with `npm start` ?
- Probably should abstract out the pin view now that there are two we can see commonalities and room for code re-use.
  - Headers strucuture / styles
  - Attribution structure / styles
  - Call to action structure / styles

**In Progress**
- Unit tests need more coverage (currently 66/35/85/64).

**Ignored**
- Pins should be same height/width
**I am waiting to make them uniform until we know what the largest pin will look like.**
- Map should have left/right margin and be centered in pin container
**I am using the material design styles for images on material cards**
- Pin highlighting
**I wanted to indicate that you could click anywhere. I would be fine with only clicking on the buttons in the action section. This would allow for multiple actions per card.**
- I kind of like the attribution on bottom with the beveled (?) separator
**I was trying to match the way attribution appears on every page Title/Attribution/Content**

