### PR TITLE
Improve handling of old shakemap products

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ export let EventpagesModule = CoreModule;
 /* Make ShakeMap required services available */
 export { EventService } from './src/app/core/event.service';
 export { StationService } from './src/app/core/station.service';
+export { MetadataService } from './src/app/core/metadata.service';
 
 /* Make ShakeMap components available */
 export { ShakemapModule } from './src/app/shakemap/shakemap.module';

--- a/src/app/core/metadata.service.spec.ts
+++ b/src/app/core/metadata.service.spec.ts
@@ -60,6 +60,22 @@ describe('MetadataService', () => {
       });
     }));
 
+    it('handles parse failure',
+        inject([MetadataService], (service: MetadataService)  => {
+
+      const spy = spyOn(service, 'onMetadata').and.throwError('test error');
+
+      service.getMetadata(PRODUCT);
+      const request = httpClient.expectOne('url');
+      request.flush('', {status: 500, statusText: 'Error'});
+
+      service.metadata$.subscribe((content) => {
+        expect(content).toEqual(null);
+        expect(service.error).toEqual(new Error('test error'));
+      });
+
+    }));
+
     it('handles null input',
         inject([MetadataService], (service: MetadataService)  => {
 

--- a/src/app/core/metadata.service.ts
+++ b/src/app/core/metadata.service.ts
@@ -20,21 +20,27 @@ export class MetadataService {
    * @param product shakemap product json
    */
   getMetadata (product: any): void {
-    if (product == null) {
-      this.metadata$.next(null);
+    if ((product == null) || (
+          !product.contents['download/info.json'])) {
+      this.onMetadata(null);
       return;
     }
+
     const metadata = product.contents['download/info.json'];
 
     this.httpClient.get(metadata.url).pipe(
-      catchError(this.handleError())
-    ).subscribe((data: any) => {
-      this.handleMetadata(data);
-    }, (e) => {
-      /*  Subscribe errored */
-      this.error = e;
-      this.metadata$.next(null);
-    });
+        catchError(this.handleError())
+      )
+      .subscribe((data: any) => {
+        try {
+          this.onMetadata(data);
+        } catch (e) {
+
+          /* Processing error */
+          this.error = e;
+          this.metadata$.next(null);
+        }
+      });
   }
 
   /**
@@ -42,7 +48,7 @@ export class MetadataService {
    *
    * @param metadata json object
    */
-  handleMetadata(metadata) {
+  onMetadata (metadata) {
     metadata = this.translate(metadata);
     this.metadata$.next(metadata);
   }
@@ -52,7 +58,7 @@ export class MetadataService {
    *
    * @param metadata object
    */
-  translate(metadata) {
+  translate (metadata) {
     // Which objects are not arrays in ShakeMap V3
     const needsTrans = {'output': ['ground_motions', 'map_information'],
                         'processing': ['ground_motion_modules', 'roi']};
@@ -80,7 +86,7 @@ export class MetadataService {
    *
    * @param obj javascript object
    */
-  obj2Arr(obj) {
+  obj2Arr (obj) {
     const arr = [];
     for (const item_id of Object.keys(obj)) {
       const item = obj[item_id];

--- a/src/app/shakemap/shakemap.module.ts
+++ b/src/app/shakemap/shakemap.module.ts
@@ -46,7 +46,8 @@ import { ProcessingComponent } from './metadata/processing/processing.component'
     ProcessingComponent
   ],
   exports: [
-    StationListComponent
+    StationListComponent,
+    MetadataComponent
   ]
 })
 export class ShakemapModule { }


### PR DESCRIPTION
closes #826

Handles missing stationlist.json and info.json products

Converts string `"null"` and `"nan"` values in stationlist.json to `null`

Converts some non-array objects into arrays to match current info.json schema

Improved test coverage for station and metadata service