### PR TITLE
Metadata

### DIFF
--- a/src/app/core/formatter.service.spec.ts
+++ b/src/app/core/formatter.service.spec.ts
@@ -23,7 +23,7 @@ describe('FormatterService', () => {
   describe('angle', () => {
     it('returns empty value when undefined', inject(
         [FormatterService], (formatter: FormatterService) => {
-      expect(formatter.angle(null, null)).toBe('&ndash;');
+      expect(formatter.angle(null, null)).toBe('-');
     }));
 
     it('formats zero angle', inject(
@@ -113,7 +113,7 @@ describe('FormatterService', () => {
       formatter.distance(0, 'units');
 
       expect(spy).toHaveBeenCalled();
-      expect(spy).toHaveBeenCalledWith(0, 1, '&ndash;', 'units');
+      expect(spy).toHaveBeenCalledWith(0, 1, '-', 'units');
     }));
   });
 

--- a/src/app/core/formatter.service.ts
+++ b/src/app/core/formatter.service.ts
@@ -12,7 +12,7 @@ export class FormatterService {
   constructor () {
     this.depthDecimals = 1;
     this.distanceDecimals = 1;
-    this.empty = '&ndash;';
+    this.empty = '-';
     this.locationDecimals = 3;
   }
 

--- a/src/app/shakemap/metadata/input/input.component.html
+++ b/src/app/shakemap/metadata/input/input.component.html
@@ -1,86 +1,104 @@
-<div *ngIf="smInput?.event_information as eventInfo">
+<div *ngIf="smInput.event_information as eventInfo">
   <mat-expansion-panel>
     <mat-expansion-panel-header>
-        <mat-panel-title>
-            Event Information
-        </mat-panel-title>
+      <mat-panel-title>
+          Event Information
+      </mat-panel-title>
     </mat-expansion-panel-header>
 
     <ng-template matExpansionPanelContent>
-
       <dl class="description-table">
-        
-        <ng-container *ngIf="eventInfo.event_description as description">
-          <dt>Description</dt>
-          <dd>{{ description }}</dd>
-        </ng-container>
 
-        <ng-container *ngIf="eventInfo.event_id as eventId">
-          <dt>ID</dt>
-          <dd>{{ eventId }}</dd>
-        </ng-container>
+        <dt>Description</dt>
+        <dd *ngIf="eventInfo.event_description as description;
+                      else missingData">
+          {{ description }}
+        </dd>
 
-        <ng-container *ngIf="eventInfo.magnitude as mag">
-          <dt>Magnitude</dt>
-          <dd>{{ mag }}</dd>
-        </ng-container>
+        <dt>ID</dt>
+        <dd *ngIf="eventInfo.event_id as eventId;
+                      else missingData">
+          {{ eventId }}
+        </dd>
 
-        <ng-container *ngIf="eventInfo.depth as depth">
-          <dt>Depth</dt>
-          <dd>{{ depth | sharedNumber:1:'km' }}</dd>
-        </ng-container>
+        <dt>Magnitude</dt>
+        <dd *ngIf="eventInfo.magnitude as mag;
+                      else missingData">
+          {{ mag }}
+        </dd>
 
-        <ng-container *ngIf="eventInfo.latitude as lat">
-          <ng-container *ngIf="eventInfo.longitude as lng">
+        <dt>Depth</dt>
+        <dd *ngIf="eventInfo.depth as depth;
+                      else missingData">
+          {{ depth | sharedNumber:1:'km' }}
+        </dd>
 
-            <dt>GPS location</dt>
+
+        <dt>GPS location</dt>
+        <ng-container *ngIf="eventInfo.latitude as lat;
+                                else missingData">
+          <ng-container *ngIf="eventInfo.longitude as lng;
+                                  else missingData">
+
             <dd>{{ [lng, lat] | sharedLocation }}</dd>
 
           </ng-container>
         </ng-container>
 
-        <ng-container *ngIf="eventInfo.origin_time as oTime">
-          <dt>Origin time</dt>
-          <dd>{{ oTime | sharedDate }}</dd>
-        </ng-container>
+        <dt>Origin time</dt>
+        <dd *ngIf="eventInfo.origin_time as oTime;
+                      else missingData">
+          {{ oTime | sharedDateTime }}
+        </dd>
 
-        <ng-container *ngIf="eventInfo.mech_src as mechSrc">
-          <dt>Mechanism</dt>
-          <dd>{{ mechSrc }}</dd>
-        </ng-container>
+        <dt>Mechanism</dt>
+        <dd *ngIf="eventInfo.mech_src as mechSrc;
+                      else missingData">
+          {{ mechSrc }}
+        </dd>
 
-        <ng-container *ngIf="eventInfo.src_mech as srcMech">
-          <dt>Mechanism source</dt>
-          <dd>{{ srcMech }}</dd>
-        </ng-container>
+        <dt>Mechanism source</dt>
+        <dd *ngIf="eventInfo.src_mech as srcMech;
+                      else missingData">
+          {{ srcMech }}
+        </dd>
 
-        <ng-container *ngIf="eventInfo.location as loc">
-          <dt>Location</dt>
-          <dd>{{ loc }}</dd>
-        </ng-container>
+        <dt>Location</dt>
+        <dd *ngIf="eventInfo.location as loc;
+                      else missingData">
+          {{ loc }}
+        </dd>
 
-        <ng-container *ngIf="eventInfo.faultfiles as faultFiles">
-          <dt>Fault files</dt>
-          <dd>{{ faultFiles }}</dd>
-        </ng-container>
+        <dt>Fault files</dt>
+        <dd *ngIf="eventInfo.faultfiles as faultFiles;
+                      else missingData">
+          {{ faultFiles }}
+        </dd>
 
-        <ng-container *ngIf="eventInfo.fault_ref as faultRef">
-          <dt>Fault reference</dt>
-          <dd>{{ faultRef }}</dd>
-        </ng-container>
+        <dt>Fault reference</dt>
+        <dd *ngIf="eventInfo.fault_ref as faultRef;
+                      else missingData">
+          {{ faultRef }}
+        </dd>
 
-        <ng-container *ngIf="eventInfo.seismic_stations as stations">
-          <dt>Number of seismic stations</dt>
-          <dd>{{ stations }}</dd>
-        </ng-container>
+        <dt>Number of seismic stations</dt>
+        <dd *ngIf="eventInfo.seismic_stations as stations;
+                      else missingData">
+          {{ stations }}
+        </dd>
 
-        <ng-container *ngIf="eventInfo.intensity_observations as intObs">
-          <dt>Number of DYFI stations</dt>
-          <dd>{{ intObs }}</dd>
-        </ng-container>
-          
+        <dt>Number of DYFI stations</dt>
+        <dd *ngIf="eventInfo.intensity_observations as intObs;
+                      else missingData">
+          {{ intObs }}
+        </dd>
+
       </dl>
 
     </ng-template>
   </mat-expansion-panel>
+
+  <ng-template #missingData>
+    <dd>{{ formatter.empty }}</dd>
+  </ng-template>
 </div>

--- a/src/app/shakemap/metadata/input/input.component.html
+++ b/src/app/shakemap/metadata/input/input.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="smInput.event_information as eventInfo">
+<div *ngIf="smInput?.event_information as eventInfo">
   <mat-expansion-panel>
     <mat-expansion-panel-header>
       <mat-panel-title>

--- a/src/app/shakemap/metadata/input/input.component.html
+++ b/src/app/shakemap/metadata/input/input.component.html
@@ -2,7 +2,7 @@
   <mat-expansion-panel>
     <mat-expansion-panel-header>
       <mat-panel-title>
-          Event Information
+        Event Information
       </mat-panel-title>
     </mat-expansion-panel-header>
 

--- a/src/app/shakemap/metadata/input/input.component.spec.ts
+++ b/src/app/shakemap/metadata/input/input.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTableModule, MatExpansionModule } from '@angular/material';
 
 import { InputComponent } from './input.component';
+import { FormatterService } from '../../../core/formatter.service';
 
 import { MockPipe } from '../../../mock-pipe';
 
@@ -10,6 +11,9 @@ describe('InputComponent', () => {
   let fixture: ComponentFixture<InputComponent>;
 
   beforeEach(async(() => {
+
+    const formatter = {};
+
     TestBed.configureTestingModule({
       imports: [
         MatTableModule,
@@ -22,6 +26,9 @@ describe('InputComponent', () => {
         MockPipe('sharedNumber'),
         MockPipe('sharedLocation'),
         MockPipe('sharedDateTime')
+      ],
+      providers: [
+        {provide: FormatterService, useValue: formatter}
       ]
     })
     .compileComponents();

--- a/src/app/shakemap/metadata/input/input.component.spec.ts
+++ b/src/app/shakemap/metadata/input/input.component.spec.ts
@@ -21,7 +21,7 @@ describe('InputComponent', () => {
         MockPipe('sharedDegrees'),
         MockPipe('sharedNumber'),
         MockPipe('sharedLocation'),
-        MockPipe('sharedDate')
+        MockPipe('sharedDateTime')
       ]
     })
     .compileComponents();

--- a/src/app/shakemap/metadata/input/input.component.ts
+++ b/src/app/shakemap/metadata/input/input.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { FormatterService } from '../../../core/formatter.service';
 
 @Component({
   selector: 'shakemap-input',
@@ -7,7 +8,7 @@ import { Component, OnInit, Input } from '@angular/core';
 })
 export class InputComponent implements OnInit {
 
-  constructor () { }
+  constructor (public formatter: FormatterService) { }
   @Input() smInput: any;
 
   ngOnInit () {

--- a/src/app/shakemap/metadata/metadata.component.html
+++ b/src/app/shakemap/metadata/metadata.component.html
@@ -1,18 +1,18 @@
 <div class="info-container" *ngIf="metadata">
 
-  <div class="input column" *ngIf="metadata.input">
+  <div class="input column" *ngIf="metadata.input as input">
     <h2>Input</h2>
-    <shakemap-input [smInput]="metadata.input"></shakemap-input>
+    <shakemap-input [smInput]="input"></shakemap-input>
   </div>
     
-  <div class="output column" *ngIf="metadata.output">
+  <div class="output column" *ngIf="metadata.output as output">
     <h2>Output</h2>
-    <shakemap-output [smOutput]="metadata.output"></shakemap-output>
+    <shakemap-output [smOutput]="output"></shakemap-output>
   </div>
 
-  <div class="processing column" *ngIf="metadata.processing">
+  <div class="processing column" *ngIf="metadata.processing as processing">
     <h2>Processing</h2>
-      <shakemap-processing [smProcessing]="metadata.processing"></shakemap-processing>
+      <shakemap-processing [smProcessing]="processing"></shakemap-processing>
   </div>
   
 </div>

--- a/src/app/shakemap/metadata/output/output.component.html
+++ b/src/app/shakemap/metadata/output/output.component.html
@@ -2,7 +2,7 @@
   <mat-expansion-panel>
     <mat-expansion-panel-header>
       <mat-panel-title>
-          Ground Motion/Intensity Information
+        Ground Motion/Intensity Information
       </mat-panel-title>
     </mat-expansion-panel-header>
 
@@ -75,7 +75,7 @@
   <mat-expansion-panel>
     <mat-expansion-panel-header>
         <mat-panel-title>
-            Map Information
+          Map Information
         </mat-panel-title>
     </mat-expansion-panel-header>
 
@@ -122,7 +122,7 @@
   <mat-expansion-panel>
     <mat-expansion-panel-header>
         <mat-panel-title>
-            Uncertainty
+          Uncertainty
         </mat-panel-title>
     </mat-expansion-panel-header>
 

--- a/src/app/shakemap/metadata/output/output.component.html
+++ b/src/app/shakemap/metadata/output/output.component.html
@@ -1,13 +1,12 @@
 <div *ngIf="smOutput">
   <mat-expansion-panel>
     <mat-expansion-panel-header>
-        <mat-panel-title>
-            Ground Motion/Intensity Information
-        </mat-panel-title>
+      <mat-panel-title>
+          Ground Motion/Intensity Information
+      </mat-panel-title>
     </mat-expansion-panel-header>
 
     <ng-template matExpansionPanelContent>
-
       <mat-table [dataSource]="smOutput.ground_motions">
         <mat-header-row *matHeaderRowDef="headers.groundMotions"></mat-header-row>
         <mat-row *matRowDef="let myRowData; columns: headers.groundMotions"></mat-row>
@@ -21,20 +20,23 @@
                       class="mat-header-cell"
                       *matCellDef="let groundMotion">
             
-            <ng-container *ngIf="names.groundMotions[groundMotion.type] as name">
+            <ng-container *ngIf="names.groundMotions[groundMotion.type] as name;
+                                    else noName">
               <ng-container *ngIf="abbreviations[groundMotion.type] as abbr;
                                     else noAbbr">
 
                 <abbr title="{{ abbr }}">{{ name }}</abbr>
-
               </ng-container>
 
               <ng-template #noAbbr>
                 {{ name }}
               </ng-template>
-
             </ng-container>
-            
+
+            <ng-template #noName>
+              {{ groundMotion.type }}
+            </ng-template>
+
           </mat-cell>
         </ng-container>
 
@@ -43,9 +45,7 @@
             Max Value in Grid
           </mat-header-cell>
           <mat-cell *matCellDef="let groundMotion">
-
             {{ groundMotion.max_grid | sharedUnits:groundMotion.units }}
-
           </mat-cell>
         </ng-container>
 
@@ -54,9 +54,7 @@
             Max Value on Land
           </mat-header-cell>
           <mat-cell *matCellDef="let groundMotion">
-
             {{ groundMotion.max | sharedUnits:groundMotion.units }}
-
           </mat-cell>
         </ng-container>
 
@@ -65,9 +63,7 @@
             Bias
           </mat-header-cell>
           <mat-cell *matCellDef="let groundMotion">
-
             {{ groundMotion.bias }}
-
           </mat-cell>
         </ng-container>
 
@@ -84,7 +80,6 @@
     </mat-expansion-panel-header>
 
     <ng-template matExpansionPanelContent>
-
       <mat-table [dataSource]="smOutput.map_information">
         <mat-header-row *matHeaderRowDef="headers.mapInformation"></mat-header-row>
         <mat-row *matRowDef="let myRowData; columns: headers.mapInformation"></mat-row>
@@ -97,9 +92,7 @@
                       [class.mat-cell]="false"
                       class="mat-header-cell"
                       *matCellDef="let mapInfo">
-
             {{ names.mapInformation[mapInfo.type] }}
-
           </mat-cell>
         </ng-container>
 
@@ -108,9 +101,7 @@
             Latitude
           </mat-header-cell>
           <mat-cell *matCellDef="let mapInfo">
-
             {{ mapInfo.latitude | sharedUnits:mapInfo.units }}
-
           </mat-cell>
         </ng-container>
 
@@ -119,9 +110,7 @@
             Longitude
           </mat-header-cell>
           <mat-cell *matCellDef="let mapInfo">
-
             {{ mapInfo.longitude | sharedUnits:mapInfo.units }}
-
           </mat-cell>
         </ng-container>
 
@@ -138,31 +127,38 @@
     </mat-expansion-panel-header>
 
     <ng-template matExpansionPanelContent>
-
       <dl class="description-table" *ngIf="smOutput.uncertainty as uncertainty">
 
-          <ng-container *ngIf="uncertainty.mean_uncertainty_ratio as ratio">
-            <dt>Mean of map uncertainty</dt>
-            <dd>{{ ratio | sharedNumber }}</dd>
-          </ng-container>
+        <dt>Mean of map uncertainty</dt>
+        <dd *ngIf="uncertainty.mean_uncertainty_ratio as ratio;
+                              else missingData">
+          {{ ratio | sharedNumber }}
+        </dd>
+        
+        <dt>Empirical ShakeMap grade</dt>
+        <dd *ngIf="uncertainty.grade as grade;
+                              else missingData">
+          {{ grade }}
+        </dd>
 
-          <ng-container *ngIf="uncertainty.grade as grade">
-            <dt>Empirical ShakeMap grade</dt>
-            <dd>{{ grade }}</dd>
-          </ng-container>
+        <dt>Flagged Seismic Stations</dt>
+        <dd *ngIf="uncertaintytotal_flagged_mi as miFlag;
+                              else missingData">
+          {{ miFlag }}
+        </dd>
 
-          <ng-container *ngIf="uncertaintytotal_flagged_mi as miFlag">
-            <dt>Flagged Seismic Stations</dt>
-            <dd>{{ miFlag }}</dd>
-          </ng-container>
+        <dt>Flagged DYFI stations</dt>
+        <dd *ngIf="uncertainty.total_flagged_pgm as pgmFlag;
+                              else missingData">
+          {{ pgmFlag }}
+        </dd>
 
-          <ng-container *ngIf="uncertainty.total_flagged_pgm as pgmFlag">
-            <dt>Flagged DYFI stations</dt>
-            <dd>{{ pgmFlag }}</dd>
-          </ng-container>
-          
       </dl>
-
     </ng-template>
   </mat-expansion-panel>
+
+  <ng-template #missingData>
+    <dd>{{ formatter.empty }}</dd>
+  </ng-template>
+
 </div>

--- a/src/app/shakemap/metadata/output/output.component.spec.ts
+++ b/src/app/shakemap/metadata/output/output.component.spec.ts
@@ -2,6 +2,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTableModule, MatExpansionModule } from '@angular/material';
 
 import { OutputComponent } from './output.component';
+import { FormatterService } from '../../../core/formatter.service';
+
 import { MockPipe } from '../../../mock-pipe';
 
 describe('OutputComponent', () => {
@@ -9,6 +11,9 @@ describe('OutputComponent', () => {
   let fixture: ComponentFixture<OutputComponent>;
 
   beforeEach(async(() => {
+
+    const formatter = {};
+
     TestBed.configureTestingModule({
       imports: [
         MatTableModule,
@@ -20,6 +25,9 @@ describe('OutputComponent', () => {
         MockPipe('sharedDegrees'),
         MockPipe('sharedNumber'),
         MockPipe('sharedUnits')
+      ],
+      providers: [
+        {provide: FormatterService, useValue: formatter}
       ]
     })
     .compileComponents();

--- a/src/app/shakemap/metadata/output/output.component.ts
+++ b/src/app/shakemap/metadata/output/output.component.ts
@@ -6,7 +6,7 @@ import { FormatterService } from '../../../core/formatter.service';
   styleUrls: ['./output.component.scss']
 })
 export class OutputComponent implements OnInit {
-  public names = {
+  public readonly names = {
     'groundMotions': {
       'PGA': 'PGA',
       'PGV': 'PGV',
@@ -32,7 +32,7 @@ export class OutputComponent implements OnInit {
       },
   };
 
-  public abbreviations = {
+  public readonly abbreviations = {
       'SA(0.3)': 'Spectral acceleration at 0.3 s',
       'SA(1.0)': 'Spectral acceleration at 1.0 s',
       'SA(3.0)': 'Spectral acceleration at 3.0 s',
@@ -45,7 +45,7 @@ export class OutputComponent implements OnInit {
       'pgv': 'Peak Ground Velocity'
   };
 
-  public headers = {
+  public readonly headers = {
     'groundMotions': ['type', 'max', 'max_on_land', 'bias'],
     'mapInformation': ['type', 'lat', 'lon']
   };

--- a/src/app/shakemap/metadata/output/output.component.ts
+++ b/src/app/shakemap/metadata/output/output.component.ts
@@ -1,23 +1,23 @@
 import { Component, OnInit, Input } from '@angular/core';
-
+import { FormatterService } from '../../../core/formatter.service';
 @Component({
   selector: 'shakemap-output',
   templateUrl: './output.component.html',
   styleUrls: ['./output.component.scss']
 })
 export class OutputComponent implements OnInit {
-  public names: any = {
+  public names = {
     'groundMotions': {
       'PGA': 'PGA',
       'PGV': 'PGV',
       'pga': 'PGA',
       'pgv': 'PGV',
-      'SA(0.3)': 'SA(0.3s)',
-      'SA(1.0)': 'SA(1.0s)',
-      'SA(3.0)': 'SA(3.0s)',
-      'psa03': 'SA(0.3s)',
-      'psa10': 'SA(1.0s)',
-      'psa30': 'SA(3.0s)',
+      'SA(0.3)': 'SA(0.3 s)',
+      'SA(1.0)': 'SA(1.0 s)',
+      'SA(3.0)': 'SA(3.0 s)',
+      'psa03': 'SA(0.3 s)',
+      'psa10': 'SA(1.0 s)',
+      'psa30': 'SA(3.0 s)',
       'bias': 'Bias',
       'MMI': 'Intensity',
       'mmi': 'Intensity',
@@ -33,24 +33,24 @@ export class OutputComponent implements OnInit {
   };
 
   public abbreviations = {
-      'SA(0.3)': 'Spectral acceleration at 0.3 seconds',
-      'SA(1.0)': 'Spectral acceleration at 1.0 seconds',
-      'SA(3.0)': 'Spectral acceleration at 3.0 seconds',
-      'psa03': 'Spectral acceleration at 0.3 seconds',
-      'psa10': 'Spectral acceleration at 1.0 seconds',
-      'psa30': 'Spectral acceleration at 1.0 seconds',
+      'SA(0.3)': 'Spectral acceleration at 0.3 s',
+      'SA(1.0)': 'Spectral acceleration at 1.0 s',
+      'SA(3.0)': 'Spectral acceleration at 3.0 s',
+      'psa03': 'Spectral acceleration at 0.3 s',
+      'psa10': 'Spectral acceleration at 1.0 s',
+      'psa30': 'Spectral acceleration at 1.0 s',
       'PGA': 'Peak Ground Acceleration',
       'PGV': 'Peak Ground Velocity',
       'pga': 'Percent of Gravitational Acceleration',
       'pgv': 'Peak Ground Velocity'
   };
 
-  public headers: any = {
+  public headers = {
     'groundMotions': ['type', 'max', 'max_on_land', 'bias'],
     'mapInformation': ['type', 'lat', 'lon']
   };
 
-  constructor () { }
+  constructor (public formatter: FormatterService) { }
   @Input () smOutput: any;
 
   ngOnInit () {

--- a/src/app/shakemap/metadata/processing/processing.component.html
+++ b/src/app/shakemap/metadata/processing/processing.component.html
@@ -1,9 +1,9 @@
 <div  *ngIf="smProcessing">
   <mat-expansion-panel>
     <mat-expansion-panel-header>
-        <mat-panel-title>
-            Ground Motion/Intensity Information
-        </mat-panel-title>
+      <mat-panel-title>
+        Ground Motion/Intensity Information
+      </mat-panel-title>
     </mat-expansion-panel-header>
 
     <ng-template matExpansionPanelContent>
@@ -16,31 +16,26 @@
             Type
           </mat-header-cell>
           <mat-cell [attr.role]="'rowheader'"
-                      [class.mat-cell]="false"
-                      class="mat-header-cell"
-                      *matCellDef="let module">
-
+              [class.mat-cell]="false"
+              class="mat-header-cell"
+              *matCellDef="let module">
 
             <ng-container *ngIf="names.ground_motion_modules[module.type] as name;
                                   else noName">
-
               <ng-container *ngIf="abbreviations[module.type] as abbr;
                                       else noAbbr">
 
                 <abbr title="{{ abbr }}">{{ name }}</abbr>
-
               </ng-container>
 
               <ng-template #noAbbr>
                 {{ name }}
               </ng-template>
-
             </ng-container>
 
             <ng-template #noName>
               {{ module.type }}
             </ng-template>
-
 
           </mat-cell>
         </ng-container>
@@ -50,9 +45,7 @@
             Module
           </mat-header-cell>
           <mat-cell *matCellDef="let module">
-
             {{ module.module }}
-
           </mat-cell>
         </ng-container>
 
@@ -61,9 +54,7 @@
             Reference
           </mat-header-cell>
           <mat-cell *matCellDef="let module">
-
             {{ module.reference }}
-
           </mat-cell>
         </ng-container>
 
@@ -82,55 +73,65 @@
     <ng-template matExpansionPanelContent>
       <dl class="description-table" *ngIf="smProcessing.miscellaneous as miscellaneous">
 
-        <ng-container *ngIf="miscellaneous.bias_max_mag as biasMaxMag">
-          <dt>Max magnitude to compute bias</dt>
-          <dd>{{ biasMaxMag }}</dd>
-        </ng-container>
+        <dt>Max magnitude to compute bias</dt>
+        <dd *ngIf="miscellaneous.bias_max_mag as biasMaxMag;
+                      else missingData">
+          {{ biasMaxMag }}
+        </dd>
 
-        <ng-container *ngIf="miscellaneous.bias_max_range as biasMaxRange">
-          <dt>Maximum distance to include station in bias</dt>
-          <dd>{{ biasMaxRange }}</dd>
-        </ng-container>
+        <dt>Maximum distance to include station in bias</dt>
+        <dd *ngIf="miscellaneous.bias_max_range as biasMaxRange;
+                      else missingData">
+          {{ biasMaxRange }}
+        </dd>
 
-        <ng-container *ngIf="miscellaneous.bias_log_amp as biasLogAmp">
-          <dt>Use log amp to compute bias</dt>
-          <dd>{{ biasLogAmp }}</dd>
-        </ng-container>
+        <dt>Use log amp to compute bias</dt>
+        <dd *ngIf="miscellaneous.bias_log_amp as biasLogAmp;
+                      else missingData">
+          {{ biasLogAmp }}
+        </dd>
 
-        <ng-container *ngIf="miscellaneous.bias_max_bias as biasMaxBias">
-          <dt>Max allowed bias</dt>
-          <dd>{{ biasMaxBias }}</dd>
-        </ng-container>
+        <dt>Max allowed bias</dt>
+        <dd *ngIf="miscellaneous.bias_max_bias as biasMaxBias;
+                      else missingData">
+          {{ biasMaxBias }}
+        </dd>
 
-        <ng-container *ngIf="miscellaneous.bias_min_bias as biasMinBias">
-          <dt>Use log amp to compute bias</dt>
-          <dd>{{ biasMinBias }}</dd>
-        </ng-container>
+        <dt>Use log amp to compute bias</dt>
+        <dd *ngIf="miscellaneous.bias_min_bias as biasMinBias;
+                      else missingData">
+          {{ biasMinBias }}
+        </dd>
 
-        <ng-container *ngIf="miscellaneous.bias_min_stations as biasMinStations">
-          <dt>Min # of stations necessary to compute bias</dt>
-          <dd>{{ biasMinStations }}</dd>
-        </ng-container>
+        <dt>Min # of stations necessary to compute bias</dt>
+        <dd *ngIf="miscellaneous.bias_min_stations as biasMinStations;
+                      else missingData">
+          {{ biasMinStations }}
+        </dd>
 
-        <ng-container *ngIf="miscellaneous.bias_norm as biasNorm">
-          <dt>Norm of the bias</dt>
-          <dd>{{ biasNorm }}</dd>
-        </ng-container>
+        <dt>Norm of the bias</dt>
+        <dd *ngIf="miscellaneous.bias_norm as biasNorm;
+                      else missingData">
+          {{ biasNorm }}
+        </dd>
 
-        <ng-container *ngIf="miscellaneous.median_dist as medDist">
-          <dt>Median distance used</dt>
-          <dd>{{ medDist }}</dd>
-        </ng-container>
+        <dt>Median distance used</dt>
+        <dd *ngIf="miscellaneous.median_dist as medDist;
+                      else missingData">
+          {{ medDist }}
+        </dd>
 
-        <ng-container *ngIf="miscellaneous.outlier_deviation_level as devLevel">
-          <dt>Outlier level (# of std dev)</dt>
-          <dd>{{ devLevel }}</dd>
-        </ng-container>
+        <dt>Outlier level (# of std dev)</dt>
+        <dd *ngIf="miscellaneous.outlier_deviation_level as devLevel;
+                      else missingData">
+          {{ devLevel }}
+        </dd>
 
-        <ng-container *ngIf="miscellaneous.outlier_max_mag as maxMag">
-          <dt>Max magnitude to flag outliers</dt>
-          <dd>{{ maxMag }}</dd>
-        </ng-container>
+        <dt>Max magnitude to flag outliers</dt>
+        <dd *ngIf="miscellaneous.outlier_max_mag as maxMag;
+                      else missingData">
+          {{ maxMag }}
+        </dd>
 
       </dl>
     </ng-template>
@@ -145,32 +146,35 @@
     </mat-expansion-panel-header>
 
     <ng-template matExpansionPanelContent>
+
       <dl class="description-table" *ngIf="smProcessing.shakemap_versions as versions">
+        <dt>Code</dt>
+        <dd *ngIf="versions.shakemap_revision as smRev;
+                      else missingData">
+          {{ smRev }}
+        </dd>
 
-        <ng-container *ngIf="versions.shakemap_revision as smRev">
-          <dt>Code</dt>
-          <dd>{{ smRev }}</dd>
-        </ng-container>
+        <dt>Github commit</dt>
+        <dd *ngIf="versions.shakemap_revision_id as smRevId;
+                      else missingData">
+          {{ smRevId }}
+        </dd>
 
-        <ng-container *ngIf="versions.shakemap_revision_id as smRevId">
-          <dt>Github commit</dt>
-          <dd>{{ smRevId }}</dd>
-        </ng-container>
+        <dt>Map version</dt>
+        <dd *ngIf="versions.map_version as version;
+                      else missingData">
+          {{ version }}
+        </dd>
 
-        <ng-container *ngIf="versions.map_version as version">
-          <dt>Map version</dt>
-          <dd>{{ version }}</dd>
-        </ng-container>
-
-        <ng-container *ngIf="versions.process_time as time">
-          <dt>Date</dt>
-          <dd>{{ time | sharedDate }}</dd>
-        </ng-container>
+        <dt>Date</dt>
+        <dd *ngIf="versions.process_time as time;
+                      else missingData">
+          {{ time | sharedDateTime }}
+        </dd>
 
       </dl>
     </ng-template>
   </mat-expansion-panel>
-
 
   <mat-expansion-panel>
     <mat-expansion-panel-header>
@@ -182,17 +186,17 @@
     <ng-template matExpansionPanelContent>
 
       <dl class="description-table" *ngIf="smProcessing.site_response as siteResp">
-
-        <ng-container *ngIf="siteResp.vs30default as vs30">
           <dt>Reference rock Vs30</dt>
-          <dd>{{ vs30 }}</dd>
-        </ng-container>
+          <dd *ngIf="siteResp.vs30default as vs30;
+                        else missingData">
+            {{ vs30 }}
+          </dd>
 
-        <ng-container *ngIf="siteResp.site_correction as site">
           <dt>Site correction applied</dt>
-          <dd>{{ site }}</dd>
-        </ng-container>
-
+          <dd *ngIf="siteResp.site_correction as site;
+                        else missingData">
+            {{ site }}
+          </dd>
       </dl>
 
     </ng-template>
@@ -217,9 +221,9 @@
             Type
           </mat-header-cell>
           <mat-cell [attr.role]="'rowheader'"
-                      [class.mat-cell]="false"
-                      class="mat-header-cell"
-                      *matCellDef="let roi">
+              [class.mat-cell]="false"
+              class="mat-header-cell"
+              *matCellDef="let roi">
 
             {{ names.roi[roi.type] ? 
                 names.roi[roi.type] : roi.type }}
@@ -232,9 +236,7 @@
             ROI
           </mat-header-cell>
           <mat-cell *matCellDef="let roi">
-            
             {{ roi.roi }}
-
           </mat-cell>
         </ng-container>
 
@@ -243,9 +245,7 @@
             Observation Decay
           </mat-header-cell>
           <mat-cell *matCellDef="let roi">
-
             {{ roi.decay }}
-            
           </mat-cell>
         </ng-container>
 
@@ -253,4 +253,8 @@
       
     </ng-template>
   </mat-expansion-panel>
+
+  <ng-template #missingData>
+    <dd>{{ formatter.empty }}</dd>
+  </ng-template>
 </div>

--- a/src/app/shakemap/metadata/processing/processing.component.html
+++ b/src/app/shakemap/metadata/processing/processing.component.html
@@ -66,7 +66,7 @@
   <mat-expansion-panel>
     <mat-expansion-panel-header>
         <mat-panel-title>
-            Miscellaneous
+          Miscellaneous
         </mat-panel-title>
     </mat-expansion-panel-header>
 
@@ -206,7 +206,7 @@
   <mat-expansion-panel>
     <mat-expansion-panel-header>
         <mat-panel-title>
-            ROI
+          ROI
         </mat-panel-title>
     </mat-expansion-panel-header>
 

--- a/src/app/shakemap/metadata/processing/processing.component.spec.ts
+++ b/src/app/shakemap/metadata/processing/processing.component.spec.ts
@@ -2,6 +2,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTableModule, MatExpansionModule } from '@angular/material';
 
 import { ProcessingComponent } from './processing.component';
+import { FormatterService } from '../../../core/formatter.service';
+
 import { MockPipe } from '../../../mock-pipe';
 
 describe('ProcessingComponent', () => {
@@ -9,6 +11,9 @@ describe('ProcessingComponent', () => {
   let fixture: ComponentFixture<ProcessingComponent>;
 
   beforeEach(async(() => {
+
+    const formatter = {};
+
     TestBed.configureTestingModule({
       imports: [
         MatTableModule,
@@ -18,7 +23,10 @@ describe('ProcessingComponent', () => {
         ProcessingComponent,
 
         MockPipe('sharedDateTime')
-        ]
+        ],
+      providers: [
+        {provide: FormatterService, useValue: formatter}
+      ]
     })
     .compileComponents();
   }));

--- a/src/app/shakemap/metadata/processing/processing.component.spec.ts
+++ b/src/app/shakemap/metadata/processing/processing.component.spec.ts
@@ -17,7 +17,7 @@ describe('ProcessingComponent', () => {
       declarations: [
         ProcessingComponent,
 
-        MockPipe('sharedDate')
+        MockPipe('sharedDateTime')
         ]
     })
     .compileComponents();

--- a/src/app/shakemap/metadata/processing/processing.component.ts
+++ b/src/app/shakemap/metadata/processing/processing.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { FormatterService } from '../../../core/formatter.service';
 
 @Component({
   selector: 'shakemap-processing',
@@ -7,7 +8,7 @@ import { Component, OnInit, Input } from '@angular/core';
 })
 export class ProcessingComponent implements OnInit {
 
-  public names: any = {
+  public names = {
     'ground_motion_modules': {
         'basin_correction': 'Basin',
         'gmpe': 'GMPE',
@@ -30,12 +31,12 @@ export class ProcessingComponent implements OnInit {
         'igmice': 'Inverse Ground Motion Intensity Conversion Equation'
   };
 
-  public headers: any = {
+  public headers = {
     'groundMotionModules': ['type', 'module', 'reference'],
     'roi': ['type', 'roi', 'observation_decay']
   };
 
-  constructor () { }
+  constructor (public formatter: FormatterService) { }
   @Input() smProcessing: any;
 
   ngOnInit () {

--- a/src/app/shakemap/metadata/processing/processing.component.ts
+++ b/src/app/shakemap/metadata/processing/processing.component.ts
@@ -8,7 +8,7 @@ import { FormatterService } from '../../../core/formatter.service';
 })
 export class ProcessingComponent implements OnInit {
 
-  public names = {
+  public readonly names = {
     'ground_motion_modules': {
         'basin_correction': 'Basin',
         'gmpe': 'GMPE',
@@ -24,14 +24,14 @@ export class ProcessingComponent implements OnInit {
     }
   };
 
-  public abbreviations = {
+  public readonly abbreviations = {
         'gmpe': 'Ground Motion Prediction Equation',
         'gmice': 'Ground Motion Intensity Conversion Equation',
         'ipe': 'Intensity Prediction Equation',
         'igmice': 'Inverse Ground Motion Intensity Conversion Equation'
   };
 
-  public headers = {
+  public readonly headers = {
     'groundMotionModules': ['type', 'module', 'reference'],
     'roi': ['type', 'roi', 'observation_decay']
   };

--- a/src/app/shared/date-time.pipe.spec.ts
+++ b/src/app/shared/date-time.pipe.spec.ts
@@ -1,6 +1,6 @@
-import { DatePipe } from './date.pipe';
+import { DateTimePipe } from './date-time.pipe';
 
-describe('DatePipe', () => {
+describe('DateTimePipe', () => {
   let formatterService,
       pipe;
 
@@ -9,7 +9,7 @@ describe('DatePipe', () => {
       dateTime: jasmine.createSpy('dateTime spy')
     };
 
-    pipe = new DatePipe(formatterService);
+    pipe = new DateTimePipe(formatterService);
   });
 
   it('create an instance', () => {

--- a/src/app/shared/date-time.pipe.ts
+++ b/src/app/shared/date-time.pipe.ts
@@ -3,9 +3,9 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { FormatterService } from '../core/formatter.service';
 
 @Pipe({
-  name: 'sharedDate'
+  name: 'sharedDateTime'
 })
-export class DatePipe implements PipeTransform {
+export class DateTimePipe implements PipeTransform {
 
   constructor (public formatter: FormatterService) { }
 

--- a/src/app/shared/degrees.pipe.spec.ts
+++ b/src/app/shared/degrees.pipe.spec.ts
@@ -20,8 +20,8 @@ describe('DegreesPipe', () => {
   it('formats correctly', () => {
     formatter.number.and.returnValue(10);
     const deg = pipe.transform(10);
-    
-    expect(deg).toEqual('10°')
+
+    expect(deg).toEqual('10°');
   });
 
   it('calls formatterService', () => {

--- a/src/app/shared/degrees.pipe.spec.ts
+++ b/src/app/shared/degrees.pipe.spec.ts
@@ -1,4 +1,5 @@
 import { DegreesPipe } from './degrees.pipe';
+import { FormatterService } from '../core/formatter.service';
 
 describe('DegreesPipe', () => {
   let formatter,
@@ -7,7 +8,7 @@ describe('DegreesPipe', () => {
   beforeEach(() => {
     formatter = {
       empty: 'default empty',
-      number: jasmine.createSpy('formatter::dateTime')
+      number: jasmine.createSpy('formatter::number')
     };
     pipe = new DegreesPipe(formatter);
   });
@@ -16,15 +17,21 @@ describe('DegreesPipe', () => {
     expect(pipe).toBeTruthy();
   });
 
+  it('formats correctly', () => {
+    formatter.number.and.returnValue(10);
+    const deg = pipe.transform(10);
+    
+    expect(deg).toEqual('10°')
+  });
 
   it('calls formatterService', () => {
     pipe.transform('value', 'decimals', 'units', 'empty');
-    expect(formatter.number).toHaveBeenCalledWith('value', 'decimals', 'empty', 'units');
+    expect(formatter.number).toHaveBeenCalledWith('value', 'decimals', 'empty');
   });
 
   it('can be called without optional arguments', () => {
     pipe.transform('value');
-    expect(formatter.number).toHaveBeenCalledWith('value', 0, formatter.empty, '°');
+    expect(formatter.number).toHaveBeenCalledWith('value', 0, formatter.empty);
   });
 
 });

--- a/src/app/shared/degrees.pipe.ts
+++ b/src/app/shared/degrees.pipe.ts
@@ -31,6 +31,6 @@ export class DegreesPipe implements PipeTransform {
       empty = this.formatter.empty): any {
     // NOTE: FormatterService uses different argument order
     const num = this.formatter.number(value, decimals, empty);
-    return `${num}${units}`
+    return `${num}${units}`;
   }
 }

--- a/src/app/shared/degrees.pipe.ts
+++ b/src/app/shared/degrees.pipe.ts
@@ -30,6 +30,7 @@ export class DegreesPipe implements PipeTransform {
       units = '°',
       empty = this.formatter.empty): any {
     // NOTE: FormatterService uses different argument order
-    return this.formatter.number(value, decimals, empty, units);
+    const num = this.formatter.number(value, decimals, empty);
+    return `${num}${units}`
   }
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -27,8 +27,8 @@ import { LocationPipe } from './location.pipe';
 import { BubbleComponent } from './bubble/bubble.component';
 
 import { StationComponent } from './station/station.component';
-import { DatePipe } from './date.pipe';
 import { TensorPipe } from './tensor.pipe';
+import { DateTimePipe } from './date-time.pipe';
 
 
 @NgModule({
@@ -60,9 +60,9 @@ import { TensorPipe } from './tensor.pipe';
     TextProductComponent,
     UncertainValueComponent,
     StationComponent,
-    DatePipe,
     NodalPlanesComponent,
-    TensorPipe
+    TensorPipe,
+    DateTimePipe
   ],
   exports: [
     AttributionComponent,
@@ -85,8 +85,8 @@ import { TensorPipe } from './tensor.pipe';
     TextProductComponent,
     UncertainValueComponent,
     StationComponent,
-    DatePipe,
-    TensorPipe
+    TensorPipe,
+    DateTimePipe
   ],
   entryComponents: [
     DownloadDialogComponent

--- a/src/app/shared/units.pipe.spec.ts
+++ b/src/app/shared/units.pipe.spec.ts
@@ -37,6 +37,6 @@ describe('UnitsPipe', () => {
 
   it('calls formatterService for degrees', () => {
     pipe.transform('value', 'degrees');
-    expect(formatter.number).toHaveBeenCalledWith('value', 0, 'default empty', '°');
+    expect(formatter.number).toHaveBeenCalledWith('value', 0, 'default empty');
   });
 });


### PR DESCRIPTION
closes #820 

Renamed `sharedDate` pipe, `sharedDateTime` for accuracy

Allowed missing values' headers to be displayed in description-tables using `formatterService.empty` as the fallback

Replaced `FormatterService`'s empy "%ndash" with "-"

sharedDegree pipe does not rely on `formatterService.number` for units formatting, since it automatically adds a space

Added space in` PS(0.3 s)` headers

Relaced "seconds" with "s" in `<abbr>` titles

Fixed some formatting and reduced whitespace

Made lookup tables in metadata rendering readonly