### PR TITLE
Support explicit map bounds

### DIFF
--- a/src/app/map/map/map.component.html
+++ b/src/app/map/map/map.component.html
@@ -1,6 +1,7 @@
 <ng-container *ngIf="eventService.event$ | async; let event">
   <ng-container *ngIf="activatedRoute.queryParamMap | async; let params">
     <shared-map
+        [bounds]="params | interactiveMapBounds"
         [overlays]="event | interactiveMapOverlays:params"
         [showLayersControl]="true"
         [showLegendControl]="true"

--- a/src/app/map/map/map.component.spec.ts
+++ b/src/app/map/map/map.component.spec.ts
@@ -24,13 +24,15 @@ describe('MapComponent', () => {
         MockComponent({
           selector: 'shared-map',
           inputs: [
+            'bounds',
             'overlays',
             'showLayersControl',
             'showLegendControl',
             'showScaleControl',
             'interactive'
           ]
-       }),
+        }),
+        MockPipe('interactiveMapBounds'),
         MockPipe('interactiveMapOverlays')
       ],
       imports: [

--- a/src/app/shared/interactive-map-bounds.pipe.spec.ts
+++ b/src/app/shared/interactive-map-bounds.pipe.spec.ts
@@ -1,0 +1,30 @@
+import { InteractiveMapBoundsPipe } from './interactive-map-bounds.pipe';
+import { convertToParamMap } from '@angular/router';
+
+describe('InteractiveMapBoundsPipe', () => {
+  it('create an instance', () => {
+    const pipe = new InteractiveMapBoundsPipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  describe('transform', () => {
+    it('returns null if params are null', () => {
+      const pipe = new InteractiveMapBoundsPipe();
+      expect(pipe.transform(undefined)).toBeNull();
+    });
+
+    it('returns null if bounds param is empty', () => {
+      const pipe = new InteractiveMapBoundsPipe();
+      expect(pipe.transform(convertToParamMap({bounds: null}))).toBeNull();
+    });
+
+    it('returns parsed bounds', () => {
+      const pipe = new InteractiveMapBoundsPipe();
+      const params = convertToParamMap({bounds: ['34,-118', '39,-105']});
+      expect(pipe.transform(params)).toEqual([
+        [34, -118],
+        [39, -105]
+      ]);
+    });
+  });
+});

--- a/src/app/shared/interactive-map-bounds.pipe.ts
+++ b/src/app/shared/interactive-map-bounds.pipe.ts
@@ -1,0 +1,30 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { ParamMap } from '@angular/router';
+
+@Pipe({
+  name: 'interactiveMapBounds'
+})
+export class InteractiveMapBoundsPipe implements PipeTransform {
+
+  transform(params: ParamMap): any {
+    if (!params) {
+      return null;
+    }
+
+    const parsed = [];
+
+    const bounds = params.getAll('bounds');
+    bounds.forEach((b) => {
+      if (!b) {
+        return;
+      }
+      parsed.push(b.split(',').map((n) => +n));
+    });
+
+    if (parsed.length === 0) {
+      return null;
+    }
+    return parsed;
+  }
+
+}

--- a/src/app/shared/map/map.component.spec.ts
+++ b/src/app/shared/map/map.component.spec.ts
@@ -26,6 +26,38 @@ describe('MapComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  describe('bounds', () => {
+    it('set calls setBounds', () => {
+      spyOn(component, 'setBounds');
+      component.bounds = null;
+      expect(component.setBounds).toHaveBeenCalled();
+    });
+
+    it('uses overlay bounds when not set', (done) => {
+      spyOn(component, 'getOverlayBounds').and.returnValue('test');
+      spyOn(component.map, 'fitBounds');
+
+      component.bounds = null;
+      expect(component.getOverlayBounds).toHaveBeenCalled();
+      setTimeout(() => {
+        expect(component.map.fitBounds).toHaveBeenCalledWith('test');
+        done();
+      }, 1);
+    });
+
+    it('uses bounds when set', (done) => {
+      spyOn(component.map, 'fitBounds');
+      const myBounds = [[12, 34], [56, 78]];
+
+      component.bounds = myBounds;
+
+      setTimeout(() => {
+        expect(component.map.fitBounds).toHaveBeenCalledWith(myBounds);
+        done();
+      }, 1);
+    });
+  });
+
   describe('overlays', () => {
     it('set calls updateOverlays', () => {
       spyOn(component, 'updateOverlays');

--- a/src/app/shared/map/map.component.ts
+++ b/src/app/shared/map/map.component.ts
@@ -16,6 +16,9 @@ export class MapComponent implements AfterViewInit, OnInit {
   @Input() baselayer = 'Topographic';
   @Input() showAttributionControl = true;
 
+  // value of bounds property
+  private _bounds: Array<Array<number>> = null;
+
   // value of overlays property
   private _overlays: Array<Overlay> = [];
 
@@ -120,6 +123,16 @@ export class MapComponent implements AfterViewInit, OnInit {
     this.updateOverlays();
   }
 
+  get bounds (): Array<Array<number>> {
+    return this._bounds;
+  }
+
+  @Input()
+  set bounds (bounds: Array<Array<number>>) {
+    this._bounds = bounds;
+    this.setBounds();
+  }
+
   @Input()
   set interactive (interactive: boolean) {
     this._interactive = interactive;
@@ -199,7 +212,12 @@ export class MapComponent implements AfterViewInit, OnInit {
       return;
     }
 
-    let bounds = this.getOverlayBounds();
+    let bounds = this.bounds;
+
+    // use overlays if no explicit bounds set
+    if (bounds === null) {
+      bounds = this.getOverlayBounds();
+    }
 
     // default to world if no overlay bounds
     if (bounds === null) {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -34,6 +34,7 @@ import { DyfiCounterPipe } from './dyfi-counter.pipe';
 import { GetProductPipe } from './get-product.pipe';
 import { GroundFailureOverlaysPipe } from './ground-failure-overlays.pipe';
 import { RegionInfoOverlaysPipe } from './region-info-overlays.pipe';
+import { InteractiveMapBoundsPipe } from './interactive-map-bounds.pipe';
 import { InteractiveMapOverlaysPipe } from './interactive-map-overlays.pipe';
 import { KeysPipe } from './keys.pipe';
 import { StationFlagComponent } from './station-flag/station-flag.component';
@@ -77,6 +78,7 @@ import { ShakemapMapOverlaysPipe } from './shakemap-map-overlays.pipe';
     DateTimePipe,
     GetProductPipe,
     GroundFailureOverlaysPipe,
+    InteractiveMapBoundsPipe,
     InteractiveMapOverlaysPipe,
     RegionInfoOverlaysPipe,
     KeysPipe,
@@ -112,6 +114,7 @@ import { ShakemapMapOverlaysPipe } from './shakemap-map-overlays.pipe';
     GetProductPipe,
     GroundFailureOverlaysPipe,
     KeysPipe,
+    InteractiveMapBoundsPipe,
     InteractiveMapOverlaysPipe,
     RegionInfoOverlaysPipe,
     ShakemapMapOverlaysPipe


### PR DESCRIPTION
- bounds parameter for embedded shared-map:

```
<shared-map
    [bounds]="[[34, -118], [35, -117]]"
    ...
```

- bounds query param when linking to interactive map:

```
<a
    [routerLink]="'../../map'"
    [queryParams]="{
      bounds: [
        [34, -118],
        [35, -117]
      ],
      'ground-failure-landslide': true
    }">
  ...
```
