### PR TITLE
Remove node_modules folder from workspace during cleanup

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -319,6 +319,9 @@ node {
       sh """
         set +e;
 
+        # Cleaning up node_modules folder...
+        rm -r node_modules;
+
         # Cleaning up any leftover containers...
         docker container rm --force \
           ${BUILDER_CONTAINER} \


### PR DESCRIPTION
node_modules is taking up around 400MB per build.

@Amills-USGS and I manually cleaned up builds older than 5 days, but jenkins is/was running low on disk space...