### PR TITLE
Using deleteDir rather than cleanWs. Space saver.

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -43,7 +43,7 @@ node {
   try {
     stage('Initialize') {
       // Clean workspace before building
-      cleanWs()
+      deleteDir()
 
       // Clone latest source
       SCM_VARS = checkout scm


### PR DESCRIPTION
The jobs archive only keeps logs, configurations, and specific artifacts for each build. It does not preserve the workspace itself. For debugging it may be necessary to keep a single copy of the workspace available after a build. For this reason, cleanup at start of next build instead.

This will keep one copy of the workspace on disk (~400 MB) but using `deleteDir` rather than `cleanWs` will prevent the duplicate workspace copies in the *cleanup* directories that were for some reason not getting deleted. 