### PR TITLE
Fix delete to work

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -100,7 +100,7 @@ node {
       // okay, but just be aware ...
 
       // Run linting, unit tests, and end-to-end tests
-      docker.image(TESTER_IMAGE).inside ("-u root") {
+      docker.image(TESTER_IMAGE).inside () {
           ansiColor('xterm') {
             sh """
               npm install --no-save


### PR DESCRIPTION
Running container as root creates artifacts in workspace owned by root and jenkins can not delete using `deleteDir`. Root was not needed on build and this allows delete to work and build to pass.