### PR TITLE
Fix Shakemap map issues

### DIFF
--- a/src/app/shakemap/intensity/intensity.component.html
+++ b/src/app/shakemap/intensity/intensity.component.html
@@ -1,29 +1,30 @@
 <ng-container *ngIf="eventService.product$ | async; let shakemap">
 
-    <a
-        [routerLink]="'../../map'"
+  <ng-container
+      *ngIf="shakemap?.contents['download/cont_mi.json']; else noOverlay">
+    <a [routerLink]="'../../map'"
         [queryParams]="{
           'shakemap-code': shakemap?.code,
           'shakemap-source': shakemap?.source,
           'shakemap-intensity': true
         }">
-
-      <ng-container
-          *ngIf="shakemap?.contents['download/cont_mi.json']; else noOverlay">
-
-        <shared-map
-            [overlays]="shakemap | shakemapOverlays:'shakemap-intensity'"
-            [showScaleControl]="true">
-        </shared-map>
-
-        <img src="./assets/shakemap-intensity-legend.png" alt="ShakeMap intensity legend">
-      </ng-container>
-
-      <ng-template #noOverlay>
-        <img
-            src="{{ shakemap.contents['download/intensity.jpg'].url }}"
-            alt="ShakeMap intensity image">
-      </ng-template>
-
+      <shared-map
+          [overlays]="shakemap | shakemapOverlays:'shakemap-intensity'"
+          [showScaleControl]="true">
+      </shared-map>
     </a>
+
+    <img
+        class="legend"
+        src="./assets/shakemap-intensity-legend.png" 
+        alt="ShakeMap intensity legend">
+  </ng-container>
+
+  <ng-template #noOverlay>
+    <img
+        *ngIf="shakemap?.contents['download/intensity.jpg']"
+        src="{{ shakemap.contents['download/intensity.jpg'].url }}"
+        alt="ShakeMap intensity image">
+  </ng-template>
+
 </ng-container>

--- a/src/app/shakemap/intensity/intensity.component.scss
+++ b/src/app/shakemap/intensity/intensity.component.scss
@@ -3,7 +3,7 @@ shared-map {
     height: 500px;
 }
 
-img {
+.legend {
     width: 100%;
     max-width: 600px;
     margin-top: 1em;

--- a/src/app/shakemap/shakemap/shakemap.component.html
+++ b/src/app/shakemap/shakemap/shakemap.component.html
@@ -6,34 +6,39 @@
     <h3>ShakeMap</h3>
   </ng-container>
 
+  <ng-container *ngIf="eventService.product$ | async; let shakemap">
   <!-- routes/components in ../origin-routing.module.ts -->
-  <nav mat-tab-nav-bar>
-    <a mat-tab-link [routerLink]="'./intensity'"
-        queryParamsHandling="preserve"
-        routerLinkActive #intensity="routerLinkActive"
-        [active]="intensity.isActive">
-      Intensity
-    </a>
-    <a mat-tab-link [routerLink]="'./metadata'"
-        queryParamsHandling="preserve"
-        routerLinkActive #metadata="routerLinkActive"
-        [active]="metadata.isActive">
-      Metadata
-    </a>
-    <a mat-tab-link [routerLink]="'./stations'"
-        queryParamsHandling="preserve"
-        routerLinkActive #stations="routerLinkActive"
-        [active]="stations.isActive">
-      Station List
-    </a>
-    <a mat-tab-link [routerLink]="'./uncertainty'"
-        queryParamsHandling="preserve"
-        routerLinkActive #uncertainty="routerLinkActive"
-        [active]="uncertainty.isActive">
-      Uncertainty
-    </a>
-  </nav>
-  <router-outlet></router-outlet>
+    <nav mat-tab-nav-bar>
+      <a *ngIf="shakemap?.contents['download/cont_mi.json'] ||
+          shakemap?.contents['download/intensity.jpg']"
+          mat-tab-link [routerLink]="'./intensity'"
+          queryParamsHandling="preserve"
+          routerLinkActive #intensity="routerLinkActive"
+          [active]="intensity.isActive">
+        Intensity
+      </a>
+      <a mat-tab-link [routerLink]="'./metadata'"
+          queryParamsHandling="preserve"
+          routerLinkActive #metadata="routerLinkActive"
+          [active]="metadata.isActive">
+        Metadata
+      </a>
+      <a mat-tab-link [routerLink]="'./stations'"
+          queryParamsHandling="preserve"
+          routerLinkActive #stations="routerLinkActive"
+          [active]="stations.isActive">
+        Station List
+      </a>
+      <a mat-tab-link [routerLink]="'./uncertainty'"
+          queryParamsHandling="preserve"
+          routerLinkActive #uncertainty="routerLinkActive"
+          [active]="uncertainty.isActive">
+        Uncertainty
+      </a>
+    </nav>
+
+    <router-outlet></router-outlet>
+  </ng-container>
 
   <!-- container with footer attribute is added before downloads -->
   <ng-container footer>

--- a/src/app/shakemap/shakemap/shakemap.component.spec.ts
+++ b/src/app/shakemap/shakemap/shakemap.component.spec.ts
@@ -2,14 +2,23 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { ShakemapComponent } from './shakemap.component';
 import { MockComponent } from 'ng2-mock-component';
+import { of } from 'rxjs/observable/of';
+
+import { ShakemapComponent } from './shakemap.component';
+import { Event } from '../../event';
+import { EventService } from '../../core/event.service';
 
 describe('ShakemapComponent', () => {
   let component: ShakemapComponent;
   let fixture: ComponentFixture<ShakemapComponent>;
 
   beforeEach(async(() => {
+    const eventServiceStub = {
+      event$: of(new Event({})),
+      product$: null
+    };
+
     TestBed.configureTestingModule({
       declarations: [
         ShakemapComponent,
@@ -19,6 +28,9 @@ describe('ShakemapComponent', () => {
       imports: [
         MatTabsModule,
         RouterTestingModule
+      ],
+      providers: [
+        { provide: EventService, useValue: eventServiceStub }
       ]
     })
     .compileComponents();

--- a/src/app/shakemap/shakemap/shakemap.component.ts
+++ b/src/app/shakemap/shakemap/shakemap.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
+import { EventService } from '../../core/event.service';
+
 @Component({
   selector: 'app-shakemap',
   templateUrl: './shakemap.component.html',
@@ -7,7 +9,7 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ShakemapComponent implements OnInit {
 
-  constructor () { }
+  constructor (public eventService: EventService) { }
 
   ngOnInit () {
   }


### PR DESCRIPTION
closes #925 

Cleaned up indentation

Removed link to the interactive map from the static intensity jpeg

Checking for intensity jpeg before displaying it

Verifying the jpeg or contours exist before displaying the intensity tab (Although there should also be some rerouting if neither of these exist because it's the landing page for the module)

Scoping legend css properties

I think I need to add the legend directly to the layer instead of the overlay, since the layer is already in the leaflet realm by the time the legend control knows about it? Setting the Overlay.legend property doesn't currently add anything to the legend; maybe we should make the Overlay.legend a get/set property, and we can let it add the legend to the layer internally?