### PR TITLE
wrap up issues from sprint

### DIFF
--- a/src/app/event-page/navigation/navigation.component.html
+++ b/src/app/event-page/navigation/navigation.component.html
@@ -14,7 +14,7 @@
   </app-navigation-group>
 
   <app-navigation-group *ngIf="hasImpact(event); else noImpact">
-    <app-navigation-item navGroupHeader display="Impact" class="not-supported"
+    <app-navigation-item navGroupHeader display="Impact"
         navRouterLink="impact"></app-navigation-item>
 
     <app-navigation-item display="Felt Report - Tell Us!"
@@ -23,10 +23,10 @@
         display="Did You Feel It?" class="not-supported"
         navRouterLink="dyfi"></app-navigation-item>
     <app-navigation-item *ngIf="event.hasProducts('shakemap')"
-        display="ShakeMap" class="not-supported"
+        display="ShakeMap"
         navRouterLink="shakemap"></app-navigation-item>
     <app-navigation-item *ngIf="event.hasProducts('losspager')"
-        display="PAGER"
+        display="PAGER" class="not-supported"
         navRouterLink="pager"></app-navigation-item>
     <app-navigation-item *ngIf="event.hasProducts('ground-failure')"
         display="Ground Failure"

--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -24,6 +24,11 @@
       </executive-shakemap-pin>
     </li>
 
+    <li *ngIf="event | getProduct:'ground-failure' let groundFailure">
+      <executive-ground-failure-pin [product]="groundFailure">
+      </executive-ground-failure-pin>
+    </li>
+
     <li *ngIf="event | getProduct:'origin'; let origin">
       <executive-origin-pin [product]="origin">
       </executive-origin-pin>
@@ -41,11 +46,6 @@
         </executive-focal-mechanism-pin>
       </li>
     </ng-template>
-
-    <li *ngIf="event | getProduct:'ground-failure' let groundFailure">
-      <executive-ground-failure-pin [product]="groundFailure">
-      </executive-ground-failure-pin>
-    </li>
   </ul>
 
   <shared-text-product

--- a/src/app/ground-failure/about/about.component.html
+++ b/src/app/ground-failure/about/about.component.html
@@ -13,7 +13,7 @@
 <div>
   <p>
     See the
-    <a href="/data/grdfailure/background.php">Ground Failure Background</a>
+    <a href="/data/ground-failure/background.php">Ground Failure Background</a>
     page for technical details about our models and alert levels.
   </p>
 </div>

--- a/src/app/ground-failure/ground-failure/ground-failure.component.html
+++ b/src/app/ground-failure/ground-failure/ground-failure.component.html
@@ -21,7 +21,7 @@
     <p>
       Due to local factors and model limitations, ground failure may still
       occur when alert levels indicate little to no hazard. Refer to
-      <a href="/data/grdfailure/background.php">Ground Failure Background</a>
+      <a href="/data/ground-failure/background.php">Ground Failure Background</a>
       for more information.
     </p>
     <p>


### PR DESCRIPTION
fixes #951 

- Change the position of the ground-failure pin. The pin should come after PAGER. 
- Remove TODO from "ShakeMap" & "Impact" on side navigation
- Update "ground failure background" link on the about tab, it should link to `/data/ground-failure/background.php`