### PR TITLE
Issue 898 fixes

### DIFF
--- a/src/app/pager/pager/pager.component.html
+++ b/src/app/pager/pager/pager.component.html
@@ -22,7 +22,8 @@
               product.contents['alertfatal.png']; else noImage">
             <figure>
               <a href="{{ product.contents['alertfatal.pdf'].url }}">
-                <img src="{{ product.contents['alertfatal.png'].url }}" />
+                <img src="{{ product.contents['alertfatal.png'].url }}"
+                    alt="Estimated Fatalities Histogram" />
               </a>
               <figcaption *ngIf="pager.comments?.impact?.fatality">
                 {{ pager.comments.impact.fatality }}
@@ -37,7 +38,8 @@
               product.contents['alertecon.png']; else noImage">
             <figure>
               <a href="{{ product.contents['alertecon.pdf'].url }}">
-                <img src="{{ product.contents['alertecon.png'].url }}" />
+                <img src="{{ product.contents['alertecon.png'].url }}"
+                    alt="Estimated Economic Losses Histogram" />
               </a>
               <figcaption *ngIf="pager.comments?.impact?.economic">
                 {{ pager.comments.impact.economic }}
@@ -54,7 +56,8 @@
               product.contents['exposure.png']; else noImage">
             <figure>
               <!-- TODO, Link to map -->
-              <img src="{{ product.contents['exposure.png'].url }}" />
+              <img src="{{ product.contents['exposure.png'].url }}"
+                  alt="Population Exposure Map" />
               <figcaption>
                 Population per ~1 sq. km. from LandScan
               </figcaption>

--- a/src/app/pager/pager/pager.component.html
+++ b/src/app/pager/pager/pager.component.html
@@ -53,9 +53,8 @@
           <ng-container *ngIf="product.contents &&
               product.contents['exposure.png']; else noImage">
             <figure>
-              <a href="#">
-                <img src="{{ product.contents['exposure.png'].url }}" />
-              </a>
+              <!-- TODO, Link to map -->
+              <img src="{{ product.contents['exposure.png'].url }}" />
               <figcaption>
                 Population per ~1 sq. km. from LandScan
               </figcaption>

--- a/src/app/pager/pager/pager.component.scss
+++ b/src/app/pager/pager/pager.component.scss
@@ -1,11 +1,10 @@
 figure {
   margin: 1em 0;
-
-  > a > img {
-    max-width: 100%;
-  }
 }
 
+img {
+  max-width: 100%;
+}
 mat-table {
 
   .mat-column-mmi,

--- a/src/app/pager/pager/pager.component.spec.ts
+++ b/src/app/pager/pager/pager.component.spec.ts
@@ -48,4 +48,13 @@ describe('PagerComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('onProduct', () => {
+    it('checks for losspager product', () => {
+      component.onProduct({});
+      expect(component.pagerXmlService.getPagerXml).not.toHaveBeenCalled();
+      component.onProduct({type: 'losspager'});
+      expect(component.pagerXmlService.getPagerXml).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/pager/pagerxml.service.spec.ts
+++ b/src/app/pager/pagerxml.service.spec.ts
@@ -212,14 +212,15 @@ describe('PagerxmlService', () => {
             international response.#Estimated economic losses are 0-1% GDP of
             Mexico.
           </impact_comment>
-          <secondary_effects/>
+          <secondary_effects>
+            testing...
+          </secondary_effects>
         </pager>`);
+      const spy = spyOn(service, '_parseImpactComments').and.returnValue({});
       const comments = service._parseComments(xml.pager);
-      expect(comments.effects).toBeUndefined();
-      expect(comments.impact).toBeDefined();
-      expect(comments.impact.economic).toBeDefined();
-      expect(comments.impact.fatality).toBeDefined();
+      expect(comments.effects).toBeDefined();
       expect(comments.structure).toBeDefined();
+      expect(spy).toHaveBeenCalled();
     }));
 
     it('returns null when response is null',
@@ -227,6 +228,30 @@ describe('PagerxmlService', () => {
 
       const comments = service._parseComments(null);
       expect(comments).toBeNull();
+    }));
+  });
+
+  describe('parseImpactComments', () => {
+    it('handles both fatality and economic processing of impact comments',
+        inject([PagerXmlService], (service: PagerXmlService) => {
+      const impact = service._parseImpactComments('testing#with economic comment');
+      expect(impact).not.toBeNull();
+      expect(impact.economic).toBeDefined();
+      expect(impact.fatality).toBeDefined();
+    }));
+    it('handles a fatality impact comment and empty economic comment',
+        inject([PagerXmlService], (service: PagerXmlService) => {
+      const impact = service._parseImpactComments('testing#');
+      expect(impact).not.toBeNull();
+      expect(impact.economic).not.toBeDefined();
+      expect(impact.fatality).toBeDefined();
+    }));
+    it('handles just a fatality impact comment',
+        inject([PagerXmlService], (service: PagerXmlService) => {
+      const impact = service._parseImpactComments('testing');
+      expect(impact).not.toBeNull();
+      expect(impact.economic).not.toBeDefined();
+      expect(impact.fatality).toBeDefined();
     }));
   });
 

--- a/src/app/pager/pagerxml.service.ts
+++ b/src/app/pager/pagerxml.service.ts
@@ -21,9 +21,6 @@ export class PagerXmlService {
 
   getPagerXml (product: any): void {
     try {
-      if (product.losspager) {
-        product = product.losspager;
-      }
       const contents = product.contents['pager.xml'];
       const options = {responseType: 'text' as 'text'};
 

--- a/src/app/pager/pagerxml.service.ts
+++ b/src/app/pager/pagerxml.service.ts
@@ -146,7 +146,6 @@ export class PagerXmlService {
   _parseComments (pager: any) {
     let effects,
         data,
-        impact,
         structure;
 
     if (!pager || (
@@ -168,31 +167,51 @@ export class PagerXmlService {
       data.effects = effects.trim();
     }
 
-    // TODO :: This is a cluster. PAGER team should sort out a better way to
-    //         send comments of this nature.
-    impact = pager.impact_comment;
-    if (impact && impact !== '' && typeof impact !== 'object') {
-      impact = impact.trim().split('#').reverse();
-      if (impact[0].indexOf('economic') !== -1) {
-        impact.reverse();
-      }
-
-      data.impact = {};
-
-      // name the comments
-      if (impact.length === 2) {
-        if (impact[0] !== '') {
-          data.impact.fatality = impact[0];
-          data.impact.economic = impact[1];
-        } else {
-          data.impact.fatality = impact[1];
-        }
-      } else {
-        data.impact.fatality = impact[0];
-      }
-    }
+    data.impact = this._parseImpactComments(pager.impact_comment);
 
     return data;
+  }
+
+  /**
+   * [_parseImpactComments description]
+   *
+   * @param comment {String}
+   *      The string representing the combinded economic and fatality
+   *      impact comment
+   *
+   * @return {Object}
+   *      An object containing parsed impact comment information.
+   *      Keyed by impact comment type.
+   */
+  _parseImpactComments (comment) {
+    let impact;
+
+    // TODO :: This is a cluster. PAGER team should sort out a better way to
+    //         send comments of this nature.
+    if (!comment || comment === '' || typeof comment === 'object') {
+      return null;
+    }
+
+    impact = {};
+
+    comment = comment.trim().split('#').reverse();
+    if (comment[0].indexOf('economic') !== -1) {
+      comment.reverse();
+    }
+
+    // name the comments
+    if (comment.length === 2) {
+      if (comment[0] !== '') {
+        impact.fatality = comment[0];
+        impact.economic = comment[1];
+      } else {
+        impact.fatality = comment[1];
+      }
+    } else {
+      impact.fatality = comment[0];
+    }
+
+    return impact;
   }
 
 


### PR DESCRIPTION
In response to @jmfee-usgs and his comments on https://github.com/usgs/earthquake-eventpages/pull/973

```
remove the # link around exposure.png; this will eventually link to the interactive map, but not ready to yet and takes you to the unknown event form
```

Done.

```
add alt text to images
```

Done.

```
does the productSubscription need to move to ngAfterViewInit? it seems like ngOnInit would also work...
```
No it doesn't need to be in ngAfterViewInit. putting the subscription works fine in ngOnInit as long as you check the product type. Pretend that you are navigating from the origin module to the pager module. When the productSubscription is created in ngOnInit, the subscription returns an origin product when the subscription is set up. By adding the subscription to the ngAfterViewInit, the first time the productSubscription triggers an update it returns the losspager product. 

```
module and service could use more test coverage
```

Added more coverage.

```
this line looks unnecessary: file:///.../git/earthquake-eventpages/coverage/earthquake-eventpages/src/app/pager/pagerxml.service.ts.html#L27
i wonder how valuable the histogram links to PDFs are, users could download them from the downloads section
```

Removed. Not sure why I had that there.