### PR TITLE
Contour overlays update

### DIFF
--- a/src/app/shakemap/intensity/intensity.component.html
+++ b/src/app/shakemap/intensity/intensity.component.html
@@ -9,7 +9,7 @@
           'shakemap-intensity': true
         }">
       <shared-map
-          [overlays]="shakemap | shakemapOverlays:'shakemap-intensity'"
+          [overlays]="shakemap | shakemapOverlays:['shakemap-intensity']"
           [showScaleControl]="true"
           [showAttributionControl]="false">
       </shared-map>
@@ -23,9 +23,13 @@
 
   <ng-template #noOverlay>
     <img
-        *ngIf="shakemap?.contents['download/intensity.jpg']"
+        *ngIf="shakemap?.contents['download/intensity.jpg']; else noImage"
         src="{{ shakemap.contents['download/intensity.jpg'].url }}"
         alt="ShakeMap intensity image">
+
+    <ng-template #noImage>
+      <h1>No intensity available for this event</h1>
+    </ng-template>
   </ng-template>
 
 </ng-container>

--- a/src/app/shakemap/intensity/intensity.component.html
+++ b/src/app/shakemap/intensity/intensity.component.html
@@ -10,7 +10,8 @@
         }">
       <shared-map
           [overlays]="shakemap | shakemapOverlays:'shakemap-intensity'"
-          [showScaleControl]="true">
+          [showScaleControl]="true"
+          [showAttributionControl]="false">
       </shared-map>
     </a>
 

--- a/src/app/shakemap/intensity/intensity.component.spec.ts
+++ b/src/app/shakemap/intensity/intensity.component.spec.ts
@@ -30,7 +30,8 @@ describe('IntensityComponent', () => {
           selector: 'shared-map',
           inputs: [
             'overlays',
-            'showScaleControl'
+            'showScaleControl',
+            'showAttributionControl'
           ]
         }),
 

--- a/src/app/shakemap/pga/pga.component.html
+++ b/src/app/shakemap/pga/pga.component.html
@@ -11,7 +11,8 @@
 
     <shared-map
         [overlays]="shakemap | shakemapOverlays:'shakemap-pga'"
-        [showScaleControl]="true">
+        [showScaleControl]="true"
+        [showAttributionControl]="false">
     </shared-map>
   </a>
 

--- a/src/app/shakemap/pga/pga.component.html
+++ b/src/app/shakemap/pga/pga.component.html
@@ -6,11 +6,13 @@
         'shakemap-code': shakemap?.code,
         'shakemap-source': shakemap?.source,
         'shakemap-pga': true,
+        'shakemap-stations': true,
         'shakemap-intensity': false
       }">
 
     <shared-map
-        [overlays]="shakemap | shakemapOverlays:'shakemap-pga'"
+        [overlays]="shakemap | shakemapOverlays:['shakemap-pga', 'shakemap-stations']"
+        [baselayer]="'Grayscale'"
         [showScaleControl]="true"
         [showAttributionControl]="false">
     </shared-map>
@@ -18,9 +20,13 @@
 
   <ng-template #noOverlay>
     <img
-        *ngIf="shakemap?.contents['download/pga.jpg']"
+        *ngIf="shakemap?.contents['download/pga.jpg']; else noImage"
         src="{{ shakemap.contents['download/pga.jpg'].url }}"
         alt="ShakeMap peak ground acceleration image">
+
+    <ng-template #noImage>
+      <h1>No PGA available for this event</h1>
+    </ng-template>
   </ng-template>
 
 </ng-container>

--- a/src/app/shakemap/pga/pga.component.spec.ts
+++ b/src/app/shakemap/pga/pga.component.spec.ts
@@ -29,7 +29,9 @@ describe('PgaComponent', () => {
           selector: 'shared-map',
           inputs: [
             'overlays',
-            'showScaleControl'
+            'showScaleControl',
+            'showAttributionControl',
+            'baselayer'
           ]
         }),
 

--- a/src/app/shakemap/pgv/pgv.component.html
+++ b/src/app/shakemap/pgv/pgv.component.html
@@ -6,11 +6,13 @@
         'shakemap-code': shakemap?.code,
         'shakemap-source': shakemap?.source,
         'shakemap-pgv': true,
+        'shakemap-stations': true,
         'shakemap-intensity': false
       }">
 
     <shared-map
-        [overlays]="shakemap | shakemapOverlays:'shakemap-pgv'"
+        [overlays]="shakemap | shakemapOverlays:['shakemap-pgv', 'shakemap-stations']"
+        [baselayer]="'Grayscale'"
         [showScaleControl]="true"
         [showAttributionControl]="false">
     </shared-map>
@@ -18,9 +20,13 @@
 
   <ng-template #noOverlay>
     <img
-        *ngIf="shakemap?.contents['download/pgv.jpg']"
+        *ngIf="shakemap?.contents['download/pgv.jpg']; else noImage"
         src="{{ shakemap.contents['download/pgv.jpg'].url }}"
         alt="ShakeMap peak ground velocity image">
+
+    <ng-template #noImage>
+      <h1>No PGV available for this event</h1>
+    </ng-template>
   </ng-template>
 
 </ng-container>

--- a/src/app/shakemap/pgv/pgv.component.html
+++ b/src/app/shakemap/pgv/pgv.component.html
@@ -11,7 +11,8 @@
 
     <shared-map
         [overlays]="shakemap | shakemapOverlays:'shakemap-pgv'"
-        [showScaleControl]="true">
+        [showScaleControl]="true"
+        [showAttributionControl]="false">
     </shared-map>
   </a>
 

--- a/src/app/shakemap/pgv/pgv.component.spec.ts
+++ b/src/app/shakemap/pgv/pgv.component.spec.ts
@@ -30,7 +30,9 @@ describe('PgvComponent', () => {
           selector: 'shared-map',
           inputs: [
             'overlays',
-            'showScaleControl'
+            'showScaleControl',
+            'showAttributionControl',
+            'baselayer'
           ]
         }),
 

--- a/src/app/shakemap/psa/psa.component.html
+++ b/src/app/shakemap/psa/psa.component.html
@@ -10,11 +10,13 @@
           'shakemap-code': shakemap?.code,
           'shakemap-source': shakemap?.source,
           'shakemap-psa03': true,
+          'shakemap-stations': true,
           'shakemap-intensity': false
         }">
 
       <shared-map
-          [overlays]="shakemap | shakemapOverlays:'shakemap-psa03'"
+          [overlays]="shakemap | shakemapOverlays:['shakemap-psa03', 'shakemap-stations']"
+          [baselayer]="'Grayscale'"
           [showScaleControl]="true"
           [showAttributionControl]="false">
       </shared-map>
@@ -23,9 +25,13 @@
 
   <ng-template #noPSA03>
     <img
-        *ngIf="shakemap?.contents['download/psa03.jpg']"
+        *ngIf="shakemap?.contents['download/psa03.jpg']; else noPSA03Image"
         src="{{ shakemap.contents['download/psa03.jpg'].url }}"
         alt="ShakeMap 0.3 s PSA (%g) image">
+
+    <ng-template #noPSA03Image>
+      <h1>No 0.3 s PSA available for this event</h1>
+    </ng-template>
   </ng-template>  
 
   <ng-container
@@ -36,11 +42,13 @@
           'shakemap-code': shakemap?.code,
           'shakemap-source': shakemap?.source,
           'shakemap-psa10': true,
+          'shakemap-stations': true,
           'shakemap-intensity': false
         }">
 
       <shared-map
-          [overlays]="shakemap | shakemapOverlays:'shakemap-psa10'"
+          [overlays]="shakemap | shakemapOverlays:['shakemap-psa10', 'shakemap-stations']"
+          [baselayer]="'Grayscale'"
           [showScaleControl]="true"
           [showAttributionControl]="false">
       </shared-map>
@@ -49,9 +57,13 @@
 
   <ng-template #noPSA10>
     <img
-        *ngIf="shakemap?.contents['download/psa10.jpg']"
+        *ngIf="shakemap?.contents['download/psa10.jpg']; else noPSA10Image"
         src="{{ shakemap.contents['download/psa10.jpg'].url }}"
         alt="ShakeMap 1.0 s PSA (%g) image">
+
+    <ng-template #noPSA10Image>
+      <h1>No 1.0 s PSA available for this event</h1>
+    </ng-template>
   </ng-template>
 
   <ng-container
@@ -62,11 +74,13 @@
           'shakemap-code': shakemap?.code,
           'shakemap-source': shakemap?.source,
           'shakemap-psa30': true,
+          'shakemap-stations': true,
           'shakemap-intensity': false
         }">
 
       <shared-map
-          [overlays]="shakemap | shakemapOverlays:'shakemap-psa30'"
+          [overlays]="shakemap | shakemapOverlays:['shakemap-psa30', 'shakemap-stations']"
+          [baselayer]="'Grayscale'"
           [showScaleControl]="true"
           [showAttributionControl]="false">
       </shared-map>
@@ -75,9 +89,13 @@
 
   <ng-template #noPSA30>
     <img
-        *ngIf="shakemap?.contents['download/psa30.jpg']"
+        *ngIf="shakemap?.contents['download/psa30.jpg']; else noPSA30Image"
         src="{{ shakemap.contents['download/psa30.jpg'].url }}"
         alt="ShakeMap 3.0 s PSA (%g) image">
+
+    <ng-template #noPSA30Image>
+      <h1>No 3.0 s PSA available for this event</h1>
+    </ng-template>
   </ng-template>  
 
 </ng-container>

--- a/src/app/shakemap/psa/psa.component.html
+++ b/src/app/shakemap/psa/psa.component.html
@@ -15,7 +15,8 @@
 
       <shared-map
           [overlays]="shakemap | shakemapOverlays:'shakemap-psa03'"
-          [showScaleControl]="true">
+          [showScaleControl]="true"
+          [showAttributionControl]="false">
       </shared-map>
     </a>
   </ng-container>
@@ -40,7 +41,8 @@
 
       <shared-map
           [overlays]="shakemap | shakemapOverlays:'shakemap-psa10'"
-          [showScaleControl]="true">
+          [showScaleControl]="true"
+          [showAttributionControl]="false">
       </shared-map>
     </a>
   </ng-container>
@@ -65,7 +67,8 @@
 
       <shared-map
           [overlays]="shakemap | shakemapOverlays:'shakemap-psa30'"
-          [showScaleControl]="true">
+          [showScaleControl]="true"
+          [showAttributionControl]="false">
       </shared-map>
     </a>
   </ng-container>

--- a/src/app/shakemap/psa/psa.component.spec.ts
+++ b/src/app/shakemap/psa/psa.component.spec.ts
@@ -30,7 +30,9 @@ describe('PsaComponent', () => {
           selector: 'shared-map',
           inputs: [
             'overlays',
-            'showScaleControl'
+            'showScaleControl',
+            'showAttributionControl',
+            'baselayer'
           ]
         }),
 

--- a/src/app/shared/css/contour-overlay.scss
+++ b/src/app/shared/css/contour-overlay.scss
@@ -3,7 +3,6 @@
   min-height: max-content;
   font-weight: bold;
   color: #000;
-  z-index: 0;
 }
 
 .contour-overlay-label .content {

--- a/src/app/shared/css/contour-overlay.scss
+++ b/src/app/shared/css/contour-overlay.scss
@@ -1,0 +1,11 @@
+.contour-overlay-label {
+  min-width: max-content;
+  min-height: max-content;
+  font-weight: bold;
+  color: #000;
+  z-index: 0;
+}
+
+.contour-overlay-label .content {
+  transform: translateX(-30%);
+}

--- a/src/app/shared/css/leaflet-styles.scss
+++ b/src/app/shared/css/leaflet-styles.scss
@@ -1,3 +1,12 @@
+@mixin leaflet-control () {
+  background: #fff;
+  border: 2px solid rgba(0,0,0,0.2);
+  border-radius: 5px;
+  float: left;
+  margin: 10px;
+  padding: 0;
+}
+
 .leaflet-bottom.leaflet-right {
   width: 100%;
 }

--- a/src/app/shared/css/station-overlay.scss
+++ b/src/app/shared/css/station-overlay.scss
@@ -126,3 +126,8 @@ dl.description-table.station-overlay {
     }
   }
 }
+
+.contour-overlay-label {
+  width: max-content;
+  height: max-content;
+}

--- a/src/app/shared/css/station-overlay.scss
+++ b/src/app/shared/css/station-overlay.scss
@@ -126,8 +126,3 @@ dl.description-table.station-overlay {
     }
   }
 }
-
-.contour-overlay-label {
-  width: max-content;
-  height: max-content;
-}

--- a/src/app/shared/map-overlay/asynchronous-geojson-overlay.ts
+++ b/src/app/shared/map-overlay/asynchronous-geojson-overlay.ts
@@ -53,7 +53,7 @@ const AsynchronousGeoJSONOverlay = L.GeoJSON.extend({
   },
 
   /**
-   * Function runs after the geoJSON layer is successfully added
+   * Runs after the geoJSON data is successfully added
    */
   afterAdd: function () {
     // subclasses should override this method

--- a/src/app/shared/map-overlay/asynchronous-geojson-overlay.ts
+++ b/src/app/shared/map-overlay/asynchronous-geojson-overlay.ts
@@ -46,6 +46,13 @@ const AsynchronousGeoJSONOverlay = L.GeoJSON.extend({
   },
 
   /**
+   * Function runs after the geoJSON layer is successfully added
+   */
+  afterAdd: function () {
+    // subclasses should override this method
+  },
+
+  /**
    * Handling all errors
    *
    * @param {Error}
@@ -80,6 +87,7 @@ const AsynchronousGeoJSONOverlay = L.GeoJSON.extend({
           this.data = data;
           // add data to layer (and map if layer still visible)
           this.addData(data);
+          this.afterAdd();
         } catch (error) {
           this.handleError(error);
         }

--- a/src/app/shared/map-overlay/asynchronous-geojson-overlay.ts
+++ b/src/app/shared/map-overlay/asynchronous-geojson-overlay.ts
@@ -30,8 +30,15 @@ const AsynchronousGeoJSONOverlay = L.GeoJSON.extend({
 
   // retain layer data to detect whether it's already loaded
   data: null,
+
+  // retain map for custom layer adjustments
+  map: null,
+
   // retain url grab errors
   error: Error,
+
+  // persistent styles (allows alternating styles in geoJSON features)
+  styles: {},
 
   initialize: function () {
     // for content downloads in async map layers; added to layer during
@@ -99,6 +106,7 @@ const AsynchronousGeoJSONOverlay = L.GeoJSON.extend({
    * Get geoJSON data and add it to the existing layer
    */
   onAdd: function (map) {
+    this.map = map;
     L.GeoJSON.prototype.onAdd.call(this, map);
 
     this.loadData();

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.spec.ts
@@ -1,0 +1,99 @@
+import { ShakemapContoursOverlay } from './shakemap-contours-overlay';
+
+import * as L from 'leaflet';
+
+
+describe('ShakemapContoursOverlay', () => {
+  let overlay;
+
+  const FEATURE = {
+    properties: {
+      value: 1
+    },
+    geometry: {
+      coordinates: [[[0, 0], [1, 1]]]
+    }
+  }
+
+  beforeEach(() => {
+    overlay = new ShakemapContoursOverlay(null);
+  });
+
+  it('can be created', () => {
+    expect(overlay).toBeTruthy();
+  });
+
+  describe('style', () => {
+    it('modifies weight', () => {
+      const style = overlay.style({});
+    });
+
+  });
+
+  describe('onEachFeature', () => {
+    it ('keeps count', () => {
+      const count = overlay._count;
+      const layer = new L.Layer();
+  
+      overlay.onEachFeature(FEATURE, layer);
+      expect(overlay._count).toBeGreaterThan(count);
+    });
+
+    it('generates new layer for even contours', () => {
+      const layer = new L.Layer();
+
+      const layerCount = Object.keys(overlay._layers).length;
+      overlay.onEachFeature(FEATURE, layer);
+
+      expect(Object.keys(overlay._layers).length).toBeGreaterThan(layerCount);
+
+    });
+
+    it('doesn\'t generate new layers for odd contours', () => {
+      const layer = new L.Layer();
+
+      const layerCount = Object.keys(overlay._layers).length;
+      overlay._count = 1;
+      overlay.onEachFeature(FEATURE, layer);
+
+      expect(Object.keys(overlay._layers).length).toEqual(layerCount);
+    });
+
+    it('ignores object without properties', () => {
+      const feature = {};
+      const layer = new L.Layer();
+
+      const layerCount = overlay._layers.length
+      overlay.onEachFeature(feature, layer);
+      expect(overlay._layers.length).toEqual(layerCount);
+
+    });
+
+  });
+
+  describe('after add', () => {
+    beforeEach(() => {
+      overlay.map = {
+        fitBounds: function (bounds) {}
+      }
+    });
+
+    it('gets bounds', () => {
+      const bounds = 'BOUNDS'
+      const spy = spyOn(overlay, 'getBounds').and.returnValue(bounds);
+
+      overlay.afterAdd();
+      expect(overlay.bounds).toBe(bounds);
+    })
+
+    it('sets map bounds', () => {
+      const bounds = 'BOUNDS'
+      const spy = spyOn(overlay, 'getBounds').and.returnValue(bounds);
+
+      const mapSpy = spyOn(overlay.map, 'fitBounds').and.callFake((bounds) => {});
+
+      overlay.afterAdd();
+      expect(mapSpy).toHaveBeenCalledWith(bounds);
+    })
+  });
+});

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.spec.ts
@@ -13,7 +13,7 @@ describe('ShakemapContoursOverlay', () => {
     geometry: {
       coordinates: [[[0, 0], [1, 1]]]
     }
-  }
+  };
 
   beforeEach(() => {
     overlay = new ShakemapContoursOverlay(null);
@@ -34,7 +34,7 @@ describe('ShakemapContoursOverlay', () => {
     it ('keeps count', () => {
       const count = overlay._count;
       const layer = new L.Layer();
-  
+
       overlay.onEachFeature(FEATURE, layer);
       expect(overlay._count).toBeGreaterThan(count);
     });
@@ -63,7 +63,7 @@ describe('ShakemapContoursOverlay', () => {
       const feature = {};
       const layer = new L.Layer();
 
-      const layerCount = overlay._layers.length
+      const layerCount = overlay._layers.length;
       overlay.onEachFeature(feature, layer);
       expect(overlay._layers.length).toEqual(layerCount);
 
@@ -75,25 +75,25 @@ describe('ShakemapContoursOverlay', () => {
     beforeEach(() => {
       overlay.map = {
         fitBounds: function (bounds) {}
-      }
+      };
     });
 
     it('gets bounds', () => {
-      const bounds = 'BOUNDS'
+      const bounds = 'BOUNDS';
       const spy = spyOn(overlay, 'getBounds').and.returnValue(bounds);
 
       overlay.afterAdd();
       expect(overlay.bounds).toBe(bounds);
-    })
+    });
 
     it('sets map bounds', () => {
-      const bounds = 'BOUNDS'
+      const bounds = 'BOUNDS';
       const spy = spyOn(overlay, 'getBounds').and.returnValue(bounds);
 
-      const mapSpy = spyOn(overlay.map, 'fitBounds').and.callFake((bounds) => {});
+      const mapSpy = spyOn(overlay.map, 'fitBounds').and.callFake((bounds_in) => {});
 
       overlay.afterAdd();
       expect(mapSpy).toHaveBeenCalledWith(bounds);
-    })
+    });
   });
 });

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.spec.ts
@@ -96,4 +96,16 @@ describe('ShakemapContoursOverlay', () => {
       expect(mapSpy).toHaveBeenCalledWith(bounds);
     });
   });
+
+  describe('getAngle', () => {
+    it('calculates the correct angle', () => {
+      const angle = overlay.getAngle([0, 0], [1, 1]);
+      expect(angle).toBe(45);
+    });
+
+    it('gives 0 for steep sections', () => {
+      const angle = overlay.getAngle([0, 0], [0, 1]);
+      expect(angle).toBe(0);
+    });
+  });
 });

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.ts
@@ -23,24 +23,24 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
 
   getUrl: function (product) {
     // override in subclass
-    return ''
+    return '';
   },
 
   onEachFeature: function (feature, layer) {
-    if (feature.properties && (this._count % 2 == 0)) {
-      const coordinates = feature.geometry.coordinates[0]
-      let coordinateIdx = Math.round(Math.random() * (coordinates.length - 2));
+    if (feature.properties && (this._count % 2 === 0)) {
+      const coordinates = feature.geometry.coordinates[0];
+      const coordinateIdx = Math.round(Math.random() * (coordinates.length - 2));
 
       // get angle for the labels
       const markerCoords = coordinates[coordinateIdx];
       const nextCoords = coordinates[coordinateIdx + 1];
 
-      const slope = ((markerCoords[1] - nextCoords[1]) / 
+      const slope = ((markerCoords[1] - nextCoords[1]) /
           (markerCoords[0] - nextCoords[0]));
 
       const angle = Math.round(Math.atan(slope) / Math.PI * 180) * -1;
-  
-      const marker = L.marker([markerCoords[1],markerCoords[0]], {
+
+      const marker = L.marker([markerCoords[1], markerCoords[0]], {
         icon: L.divIcon({
           className: 'contour-overlay-label',
           html: `<div
@@ -54,8 +54,8 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
           iconAnchor: [7, 8]
         })
       });
-      
-      this.addLayer(marker)
+
+      this.addLayer(marker);
     }
 
     this._count += 1;
@@ -63,7 +63,7 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
 
   createLabel: function (feature) {
     // Overwrite in subclass
-    return ''
+    return '';
   },
 
   style: function (feature) {

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.ts
@@ -38,7 +38,10 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
       const slope = ((markerCoords[1] - nextCoords[1]) /
           (markerCoords[0] - nextCoords[0]));
 
-      const angle = Math.round(Math.atan(slope) / Math.PI * 180) * -1;
+      let angle = Math.round(Math.atan(slope) / Math.PI * 180) * -1;
+      if ((angle > 50) || angle < -50) {
+        angle = 0;
+      }
 
       const marker = L.marker([markerCoords[1], markerCoords[0]], {
         icon: L.divIcon({

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.ts
@@ -1,0 +1,83 @@
+import * as L from 'leaflet';
+
+import { AsynchronousGeoJSONOverlay } from './asynchronous-geojson-overlay';
+
+
+const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
+
+  id: 'shakemap-contour',
+  title: 'Shakemap Contour',
+  legend: null,
+  _count: 0,
+
+  initialize: function (product) {
+    AsynchronousGeoJSONOverlay.prototype.initialize.call(this);
+
+    this.url = this.getUrl(product);
+  },
+
+  afterAdd: function () {
+    this.bounds = this.getBounds();
+    this.map.fitBounds(this.bounds);
+  },
+
+  getUrl: function (product) {
+    // override in subclass
+    return ''
+  },
+
+  onEachFeature: function (feature, layer) {
+    if (feature.properties && (this._count % 2 == 0)) {
+      const coordinates = feature.geometry.coordinates[0]
+      let coordinateIdx = Math.round(Math.random() * (coordinates.length - 2));
+
+      // get angle for the labels
+      const markerCoords = coordinates[coordinateIdx];
+      const nextCoords = coordinates[coordinateIdx + 1];
+
+      const slope = ((markerCoords[1] - nextCoords[1]) / 
+          (markerCoords[0] - nextCoords[0]));
+
+      const angle = Math.round(Math.atan(slope) / Math.PI * 180) * -1;
+  
+      const marker = L.marker([markerCoords[1],markerCoords[0]], {
+        icon: L.divIcon({
+          className: 'contour-overlay-label',
+          html: `<div
+              class="content">
+                <div
+                style="transform: rotate(${angle}deg)">
+                  ${this.createLabel(feature)}
+                </div>
+              </div>`,
+          iconSize: [14, 10],
+          iconAnchor: [7, 8]
+        })
+      });
+      
+      this.addLayer(marker)
+    }
+
+    this._count += 1;
+  },
+
+  createLabel: function (feature) {
+    // Overwrite in subclass
+    return ''
+  },
+
+  style: function (feature) {
+    // set default line style
+    // weight oscillates
+    const lineStyle = {
+      'color': '#fff',
+      'opacity': 1,
+      'weight': 4 - (this._count % 2) * 2
+    };
+
+    return lineStyle;
+  }
+
+});
+
+export { ShakemapContoursOverlay };

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.ts
@@ -13,7 +13,6 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
   initialize: function (product) {
     AsynchronousGeoJSONOverlay.prototype.initialize.call(this);
 
-    this.url = this.getUrl(product);
   },
 
   afterAdd: function () {
@@ -21,9 +20,24 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
     this.map.fitBounds(this.bounds);
   },
 
-  getUrl: function (product) {
-    // override in subclass
+  /**
+   * Generates label content that will be displayed inline with the contour
+   */
+  createLabel: function (feature) {
+    // Overwrite in subclass
     return '';
+  },
+
+  getAngle: function(point1, point2) {
+    const slope = ((point2[1] - point1[1]) /
+        (point2[0] - point1[0]));
+
+    let angle = Math.round(Math.atan(slope) / Math.PI * 180);
+    if ((angle > 50) || angle < -50) {
+      angle = 0;
+    }
+
+    return angle;
   },
 
   onEachFeature: function (feature, layer) {
@@ -34,14 +48,7 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
       // get angle for the labels
       const markerCoords = coordinates[coordinateIdx];
       const nextCoords = coordinates[coordinateIdx + 1];
-
-      const slope = ((markerCoords[1] - nextCoords[1]) /
-          (markerCoords[0] - nextCoords[0]));
-
-      let angle = Math.round(Math.atan(slope) / Math.PI * 180) * -1;
-      if ((angle > 50) || angle < -50) {
-        angle = 0;
-      }
+      const angle = this.getAngle(markerCoords, nextCoords) * -1;
 
       const marker = L.marker([markerCoords[1], markerCoords[0]], {
         icon: L.divIcon({
@@ -62,11 +69,6 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
     }
 
     this._count += 1;
-  },
-
-  createLabel: function (feature) {
-    // Overwrite in subclass
-    return '';
   },
 
   style: function (feature) {

--- a/src/app/shared/map-overlay/shakemap-pga-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-pga-overlay.spec.ts
@@ -4,8 +4,22 @@ import * as L from 'leaflet';
 
 
 describe('ShakemapPGAOverlay', () => {
+  let overlay;
+  const FEATURE = {
+    properties: {
+      value: 1
+    },
+    geometry: {
+      coordinates: [[[0, 0], [1, 1]]]
+    }
+  }
+
+  beforeEach(() => {
+    overlay = new ShakemapPGAOverlay(null);
+  });
+
   it('can be created', () => {
-    expect(new ShakemapPGAOverlay(null)).toBeTruthy();
+    expect(overlay).toBeTruthy();
   });
 
   it('uses product when defined', () => {
@@ -20,44 +34,10 @@ describe('ShakemapPGAOverlay', () => {
     expect(overlay.data).toBe(null);
   });
 
-  describe('style', () => {
-    it('runs', () => {
+  it('creates a label', () => {
+    const label = overlay.createLabel(FEATURE);
 
-      const overlay = new ShakemapPGAOverlay(null);
-      const style = overlay.style({});
-    });
+    expect(label).toBeTruthy();
+  })
 
-  });
-
-  describe('onEachFeature', () => {
-    it('generates popup', () => {
-      const feature = {
-        properties: {
-          color: 'COLOR',
-          value: 5
-        }
-      };
-
-      const overlay = new ShakemapPGAOverlay(null);
-      const layer = new L.Layer();
-
-      overlay.onEachFeature(feature, layer);
-
-      expect(layer._popup).toBeDefined();
-
-    });
-
-    it('ignores object without properties', () => {
-      const feature = {};
-
-      const overlay = new ShakemapPGAOverlay(null);
-      const layer = new L.Layer();
-
-      overlay.onEachFeature(feature, layer);
-
-      expect(layer._popup).toBeUndefined();
-
-    });
-
-  });
 });

--- a/src/app/shared/map-overlay/shakemap-pga-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-pga-overlay.spec.ts
@@ -12,7 +12,7 @@ describe('ShakemapPGAOverlay', () => {
     geometry: {
       coordinates: [[[0, 0], [1, 1]]]
     }
-  }
+  };
 
   beforeEach(() => {
     overlay = new ShakemapPGAOverlay(null);
@@ -23,7 +23,7 @@ describe('ShakemapPGAOverlay', () => {
   });
 
   it('uses product when defined', () => {
-    const overlay = new ShakemapPGAOverlay({
+    overlay = new ShakemapPGAOverlay({
       contents: {
         'download/cont_pga.json': {url: 'URL'}
       }
@@ -38,6 +38,6 @@ describe('ShakemapPGAOverlay', () => {
     const label = overlay.createLabel(FEATURE);
 
     expect(label).toBeTruthy();
-  })
+  });
 
 });

--- a/src/app/shared/map-overlay/shakemap-pga-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-pga-overlay.ts
@@ -15,6 +15,12 @@ const ShakemapPGAOverlay = AsynchronousGeoJSONOverlay.extend({
     this.url = this.getUrl(product);
   },
 
+  afterAdd: function () {
+    this.eachLayer((layer) => {
+      layer.openTooltip();
+    });
+  },
+
   getUrl: function (product) {
     if (product == null) {
       return null;
@@ -26,7 +32,11 @@ const ShakemapPGAOverlay = AsynchronousGeoJSONOverlay.extend({
 
   onEachFeature: function (feature, layer) {
     if (feature.properties) {
-      layer.bindPopup(`${feature.properties.value} %g`);
+      const t = L.tooltip({
+        permanent: true
+      }).setContent(`${feature.properties.value} %g`);
+
+      layer.bindTooltip(t);
     }
   },
 

--- a/src/app/shared/map-overlay/shakemap-pga-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-pga-overlay.ts
@@ -1,24 +1,18 @@
 import * as L from 'leaflet';
 
-import { AsynchronousGeoJSONOverlay } from './asynchronous-geojson-overlay';
+import { ShakemapContoursOverlay } from './shakemap-contours-overlay';
 
 
-const ShakemapPGAOverlay = AsynchronousGeoJSONOverlay.extend({
+const ShakemapPGAOverlay = ShakemapContoursOverlay.extend({
 
   id: 'shakemap-pga',
   title: 'Shakemap PGA Contours',
   legend: null,
 
   initialize: function (product) {
-    AsynchronousGeoJSONOverlay.prototype.initialize.call(this);
+    ShakemapContoursOverlay.prototype.initialize.call(this);
 
     this.url = this.getUrl(product);
-  },
-
-  afterAdd: function () {
-    this.eachLayer((layer) => {
-      layer.openTooltip();
-    });
   },
 
   getUrl: function (product) {
@@ -30,25 +24,9 @@ const ShakemapPGAOverlay = AsynchronousGeoJSONOverlay.extend({
          product.contents['download/cont_pga.json'].url : null;
   },
 
-  onEachFeature: function (feature, layer) {
-    if (feature.properties) {
-      const t = L.tooltip({
-        permanent: true
-      }).setContent(`${feature.properties.value} %g`);
-
-      layer.bindTooltip(t);
-    }
+  createLabel: function (feature) {
+    return `${feature.properties.value} %g`;
   },
-
-  style: function (feature) {
-    // set default line style
-    const lineStyle = {
-      'color': '#fff',
-      'opacity': 1
-    };
-
-    return lineStyle;
-  }
 
 });
 

--- a/src/app/shared/map-overlay/shakemap-pgv-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-pgv-overlay.spec.ts
@@ -4,6 +4,20 @@ import * as L from 'leaflet';
 
 
 describe('ShakemapPGVOverlay', () => {
+  let overlay;
+  const FEATURE = {
+    properties: {
+      value: 1
+    },
+    geometry: {
+      coordinates: [[[0, 0], [1, 1]]]
+    }
+  }
+
+  beforeEach(() => {
+    overlay = new ShakemapPGVOverlay(null);
+  });
+
   it('can be created', () => {
     expect(new ShakemapPGVOverlay(null)).toBeTruthy();
   });
@@ -20,44 +34,9 @@ describe('ShakemapPGVOverlay', () => {
     expect(overlay.data).toBe(null);
   });
 
-  describe('style', () => {
-    it('runs', () => {
+  it('creates a label', () => {
+    const label = overlay.createLabel(FEATURE);
 
-      const overlay = new ShakemapPGVOverlay(null);
-      const style = overlay.style({});
-    });
-
-  });
-
-  describe('onEachFeature', () => {
-    it('generates popup', () => {
-      const feature = {
-        properties: {
-          color: 'COLOR',
-          value: 5
-        }
-      };
-
-      const overlay = new ShakemapPGVOverlay(null);
-      const layer = new L.Layer();
-
-      overlay.onEachFeature(feature, layer);
-
-      expect(layer._popup).toBeDefined();
-
-    });
-
-    it('ignores object without properties', () => {
-      const feature = {};
-
-      const overlay = new ShakemapPGVOverlay(null);
-      const layer = new L.Layer();
-
-      overlay.onEachFeature(feature, layer);
-
-      expect(layer._popup).toBeUndefined();
-
-    });
-
-  });
+    expect(label).toBeTruthy();
+  })
 });

--- a/src/app/shared/map-overlay/shakemap-pgv-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-pgv-overlay.spec.ts
@@ -12,7 +12,7 @@ describe('ShakemapPGVOverlay', () => {
     geometry: {
       coordinates: [[[0, 0], [1, 1]]]
     }
-  }
+  };
 
   beforeEach(() => {
     overlay = new ShakemapPGVOverlay(null);
@@ -23,7 +23,7 @@ describe('ShakemapPGVOverlay', () => {
   });
 
   it('uses product when defined', () => {
-    const overlay = new ShakemapPGVOverlay({
+    overlay = new ShakemapPGVOverlay({
       contents: {
         'download/cont_pgv.json': {url: 'URL'}
       }
@@ -38,5 +38,5 @@ describe('ShakemapPGVOverlay', () => {
     const label = overlay.createLabel(FEATURE);
 
     expect(label).toBeTruthy();
-  })
+  });
 });

--- a/src/app/shared/map-overlay/shakemap-pgv-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-pgv-overlay.ts
@@ -15,6 +15,12 @@ const ShakemapPGVOverlay = AsynchronousGeoJSONOverlay.extend({
     this.url = this.getUrl(product);
   },
 
+  afterAdd: function () {
+    this.eachLayer((layer) => {
+      layer.openTooltip();
+    });
+  },
+
   getUrl: function (product) {
     if (product == null) {
       return null;
@@ -26,7 +32,11 @@ const ShakemapPGVOverlay = AsynchronousGeoJSONOverlay.extend({
 
   onEachFeature: function (feature, layer) {
     if (feature.properties) {
-      layer.bindPopup(`${feature.properties.value} cm/s`);
+      const t = L.tooltip({
+        permanent: true
+      }).setContent(`${feature.properties.value} cm/s`);
+
+      layer.bindTooltip(t);
     }
   },
 

--- a/src/app/shared/map-overlay/shakemap-pgv-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-pgv-overlay.ts
@@ -1,24 +1,18 @@
 import * as L from 'leaflet';
 
-import { AsynchronousGeoJSONOverlay } from './asynchronous-geojson-overlay';
+import { ShakemapContoursOverlay } from './shakemap-contours-overlay';
 
 
-const ShakemapPGVOverlay = AsynchronousGeoJSONOverlay.extend({
+const ShakemapPGVOverlay = ShakemapContoursOverlay.extend({
 
   id: 'shakemap-pgv',
   title: 'Shakemap PGV Contours',
   legend: null,
 
   initialize: function (product) {
-    AsynchronousGeoJSONOverlay.prototype.initialize.call(this);
+    ShakemapContoursOverlay.prototype.initialize.call(this);
 
     this.url = this.getUrl(product);
-  },
-
-  afterAdd: function () {
-    this.eachLayer((layer) => {
-      layer.openTooltip();
-    });
   },
 
   getUrl: function (product) {
@@ -30,25 +24,9 @@ const ShakemapPGVOverlay = AsynchronousGeoJSONOverlay.extend({
          product.contents['download/cont_pgv.json'].url : null;
   },
 
-  onEachFeature: function (feature, layer) {
-    if (feature.properties) {
-      const t = L.tooltip({
-        permanent: true
-      }).setContent(`${feature.properties.value} cm/s`);
-
-      layer.bindTooltip(t);
-    }
+  createLabel: function (feature) {
+    return `${feature.properties.value} cm/s`;
   },
-
-  style: function (feature) {
-    // set default line style
-    const lineStyle = {
-      'color': '#fff',
-      'opacity': 1
-    };
-
-    return lineStyle;
-  }
 
 });
 

--- a/src/app/shared/map-overlay/shakemap-psa03-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-psa03-overlay.spec.ts
@@ -4,6 +4,20 @@ import * as L from 'leaflet';
 
 
 describe('ShakemapPSA03Overlay', () => {
+  let overlay;
+  const FEATURE = {
+    properties: {
+      value: 1
+    },
+    geometry: {
+      coordinates: [[[0, 0], [1, 1]]]
+    }
+  }
+
+  beforeEach(() => {
+    overlay = new ShakemapPSA03Overlay(null);
+  });
+
   it('can be created', () => {
     expect(new ShakemapPSA03Overlay(null)).toBeTruthy();
   });
@@ -20,44 +34,9 @@ describe('ShakemapPSA03Overlay', () => {
     expect(overlay.data).toBe(null);
   });
 
-  describe('style', () => {
-    it('runs', () => {
+  it('creates a label', () => {
+    const label = overlay.createLabel(FEATURE);
 
-      const overlay = new ShakemapPSA03Overlay(null);
-      const style = overlay.style({});
-    });
-
-  });
-
-  describe('onEachFeature', () => {
-    it('generates popup', () => {
-      const feature = {
-        properties: {
-          color: 'COLOR',
-          value: 5
-        }
-      };
-
-      const overlay = new ShakemapPSA03Overlay(null);
-      const layer = new L.Layer();
-
-      overlay.onEachFeature(feature, layer);
-
-      expect(layer._popup).toBeDefined();
-
-    });
-
-    it('ignores object without properties', () => {
-      const feature = {};
-
-      const overlay = new ShakemapPSA03Overlay(null);
-      const layer = new L.Layer();
-
-      overlay.onEachFeature(feature, layer);
-
-      expect(layer._popup).toBeUndefined();
-
-    });
-
-  });
+    expect(label).toBeTruthy();
+  })
 });

--- a/src/app/shared/map-overlay/shakemap-psa03-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-psa03-overlay.spec.ts
@@ -12,7 +12,7 @@ describe('ShakemapPSA03Overlay', () => {
     geometry: {
       coordinates: [[[0, 0], [1, 1]]]
     }
-  }
+  };
 
   beforeEach(() => {
     overlay = new ShakemapPSA03Overlay(null);
@@ -23,7 +23,7 @@ describe('ShakemapPSA03Overlay', () => {
   });
 
   it('uses product when defined', () => {
-    const overlay = new ShakemapPSA03Overlay({
+    overlay = new ShakemapPSA03Overlay({
       contents: {
         'download/cont_psa03.json': {url: 'URL'}
       }
@@ -38,5 +38,5 @@ describe('ShakemapPSA03Overlay', () => {
     const label = overlay.createLabel(FEATURE);
 
     expect(label).toBeTruthy();
-  })
+  });
 });

--- a/src/app/shared/map-overlay/shakemap-psa03-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-psa03-overlay.ts
@@ -26,8 +26,19 @@ const ShakemapPSA03Overlay = AsynchronousGeoJSONOverlay.extend({
 
   onEachFeature: function (feature, layer) {
     if (feature.properties) {
-      layer.bindPopup(`${feature.properties.value} %g`);
+      const p = L.popup({
+        autoClose: false,
+        autoPan: false
+      }).setContent(`${feature.properties.value} %g`);
+
+      layer.bindPopup(p);
     }
+  },
+
+  afterAdd: function () {
+    this.eachLayer((layer) => {
+      layer.openPopup();
+    });
   },
 
   style: function (feature) {

--- a/src/app/shared/map-overlay/shakemap-psa03-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-psa03-overlay.ts
@@ -15,6 +15,12 @@ const ShakemapPSA03Overlay = AsynchronousGeoJSONOverlay.extend({
     this.url = this.getUrl(product);
   },
 
+  afterAdd: function () {
+    this.eachLayer((layer) => {
+      layer.openTooltip();
+    });
+  },
+
   getUrl: function (product) {
     if (product == null) {
       return null;
@@ -32,12 +38,6 @@ const ShakemapPSA03Overlay = AsynchronousGeoJSONOverlay.extend({
 
       layer.bindTooltip(t);
     }
-  },
-
-  afterAdd: function () {
-    this.eachLayer((layer) => {
-      layer.openTooltip();
-    });
   },
 
   style: function (feature) {

--- a/src/app/shared/map-overlay/shakemap-psa03-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-psa03-overlay.ts
@@ -26,18 +26,17 @@ const ShakemapPSA03Overlay = AsynchronousGeoJSONOverlay.extend({
 
   onEachFeature: function (feature, layer) {
     if (feature.properties) {
-      const p = L.popup({
-        autoClose: false,
-        autoPan: false
+      const t = L.tooltip({
+        permanent: true
       }).setContent(`${feature.properties.value} %g`);
 
-      layer.bindPopup(p);
+      layer.bindTooltip(t);
     }
   },
 
   afterAdd: function () {
     this.eachLayer((layer) => {
-      layer.openPopup();
+      layer.openTooltip();
     });
   },
 

--- a/src/app/shared/map-overlay/shakemap-psa03-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-psa03-overlay.ts
@@ -1,24 +1,18 @@
 import * as L from 'leaflet';
 
-import { AsynchronousGeoJSONOverlay } from './asynchronous-geojson-overlay';
+import { ShakemapContoursOverlay } from './shakemap-contours-overlay';
 
 
-const ShakemapPSA03Overlay = AsynchronousGeoJSONOverlay.extend({
+const ShakemapPSA03Overlay = ShakemapContoursOverlay.extend({
 
   id: 'shakemap-psa03',
   title: 'Shakemap PSA03 Contours',
   legend: null,
 
   initialize: function (product) {
-    AsynchronousGeoJSONOverlay.prototype.initialize.call(this);
+    ShakemapContoursOverlay.prototype.initialize.call(this);
 
     this.url = this.getUrl(product);
-  },
-
-  afterAdd: function () {
-    this.eachLayer((layer) => {
-      layer.openTooltip();
-    });
   },
 
   getUrl: function (product) {
@@ -30,24 +24,8 @@ const ShakemapPSA03Overlay = AsynchronousGeoJSONOverlay.extend({
          product.contents['download/cont_psa03.json'].url : null;
   },
 
-  onEachFeature: function (feature, layer) {
-    if (feature.properties) {
-      const t = L.tooltip({
-        permanent: true
-      }).setContent(`${feature.properties.value} %g`);
-
-      layer.bindTooltip(t);
-    }
-  },
-
-  style: function (feature) {
-    // set default line style
-    const lineStyle = {
-      'color': '#fff',
-      'opacity': 1
-    };
-
-    return lineStyle;
+  createLabel: function (feature) {
+    return `${feature.properties.value} %g`;
   }
 
 });

--- a/src/app/shared/map-overlay/shakemap-psa10-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-psa10-overlay.spec.ts
@@ -12,7 +12,7 @@ describe('ShakemapPSA10Overlay', () => {
     geometry: {
       coordinates: [[[0, 0], [1, 1]]]
     }
-  }
+  };
 
   beforeEach(() => {
     overlay = new ShakemapPSA10Overlay(null);
@@ -23,7 +23,7 @@ describe('ShakemapPSA10Overlay', () => {
   });
 
   it('uses product when defined', () => {
-    const overlay = new ShakemapPSA10Overlay({
+    overlay = new ShakemapPSA10Overlay({
       contents: {
         'download/cont_psa10.json': {url: 'URL'}
       }
@@ -38,5 +38,5 @@ describe('ShakemapPSA10Overlay', () => {
     const label = overlay.createLabel(FEATURE);
 
     expect(label).toBeTruthy();
-  })
+  });
 });

--- a/src/app/shared/map-overlay/shakemap-psa10-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-psa10-overlay.spec.ts
@@ -4,6 +4,20 @@ import * as L from 'leaflet';
 
 
 describe('ShakemapPSA10Overlay', () => {
+  let overlay;
+  const FEATURE = {
+    properties: {
+      value: 1
+    },
+    geometry: {
+      coordinates: [[[0, 0], [1, 1]]]
+    }
+  }
+
+  beforeEach(() => {
+    overlay = new ShakemapPSA10Overlay(null);
+  });
+
   it('can be created', () => {
     expect(new ShakemapPSA10Overlay(null)).toBeTruthy();
   });
@@ -20,44 +34,9 @@ describe('ShakemapPSA10Overlay', () => {
     expect(overlay.data).toBe(null);
   });
 
-  describe('style', () => {
-    it('runs', () => {
+  it('creates a label', () => {
+    const label = overlay.createLabel(FEATURE);
 
-      const overlay = new ShakemapPSA10Overlay(null);
-      const style = overlay.style({});
-    });
-
-  });
-
-  describe('onEachFeature', () => {
-    it('generates popup', () => {
-      const feature = {
-        properties: {
-          color: 'COLOR',
-          value: 5
-        }
-      };
-
-      const overlay = new ShakemapPSA10Overlay(null);
-      const layer = new L.Layer();
-
-      overlay.onEachFeature(feature, layer);
-
-      expect(layer._popup).toBeDefined();
-
-    });
-
-    it('ignores object without properties', () => {
-      const feature = {};
-
-      const overlay = new ShakemapPSA10Overlay(null);
-      const layer = new L.Layer();
-
-      overlay.onEachFeature(feature, layer);
-
-      expect(layer._popup).toBeUndefined();
-
-    });
-
-  });
+    expect(label).toBeTruthy();
+  })
 });

--- a/src/app/shared/map-overlay/shakemap-psa10-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-psa10-overlay.ts
@@ -26,8 +26,18 @@ const ShakemapPSA10Overlay = AsynchronousGeoJSONOverlay.extend({
 
   onEachFeature: function (feature, layer) {
     if (feature.properties) {
-      layer.bindPopup(`${feature.properties.value} %g`);
+      const t = L.tooltip({
+        permanent: true
+      }).setContent(`${feature.properties.value} %g`);
+
+      layer.bindTooltip(t);
     }
+  },
+
+  afterAdd: function () {
+    this.eachLayer((layer) => {
+      layer.openTooltip();
+    });
   },
 
   style: function (feature) {

--- a/src/app/shared/map-overlay/shakemap-psa10-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-psa10-overlay.ts
@@ -15,6 +15,12 @@ const ShakemapPSA10Overlay = AsynchronousGeoJSONOverlay.extend({
     this.url = this.getUrl(product);
   },
 
+  afterAdd: function () {
+    this.eachLayer((layer) => {
+      layer.openTooltip();
+    });
+  },
+
   getUrl: function (product) {
     if (product == null) {
       return null;
@@ -32,12 +38,6 @@ const ShakemapPSA10Overlay = AsynchronousGeoJSONOverlay.extend({
 
       layer.bindTooltip(t);
     }
-  },
-
-  afterAdd: function () {
-    this.eachLayer((layer) => {
-      layer.openTooltip();
-    });
   },
 
   style: function (feature) {

--- a/src/app/shared/map-overlay/shakemap-psa10-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-psa10-overlay.ts
@@ -1,24 +1,18 @@
 import * as L from 'leaflet';
 
-import { AsynchronousGeoJSONOverlay } from './asynchronous-geojson-overlay';
+import { ShakemapContoursOverlay } from './shakemap-contours-overlay';
 
 
-const ShakemapPSA10Overlay = AsynchronousGeoJSONOverlay.extend({
+const ShakemapPSA10Overlay = ShakemapContoursOverlay.extend({
 
   id: 'shakemap-psa10',
   title: 'Shakemap PSA10 Contours',
   legend: null,
 
   initialize: function (product) {
-    AsynchronousGeoJSONOverlay.prototype.initialize.call(this);
+    ShakemapContoursOverlay.prototype.initialize.call(this);
 
     this.url = this.getUrl(product);
-  },
-
-  afterAdd: function () {
-    this.eachLayer((layer) => {
-      layer.openTooltip();
-    });
   },
 
   getUrl: function (product) {
@@ -30,24 +24,8 @@ const ShakemapPSA10Overlay = AsynchronousGeoJSONOverlay.extend({
          product.contents['download/cont_psa10.json'].url : null;
   },
 
-  onEachFeature: function (feature, layer) {
-    if (feature.properties) {
-      const t = L.tooltip({
-        permanent: true
-      }).setContent(`${feature.properties.value} %g`);
-
-      layer.bindTooltip(t);
-    }
-  },
-
-  style: function (feature) {
-    // set default line style
-    const lineStyle = {
-      'color': '#fff',
-      'opacity': 1
-    };
-
-    return lineStyle;
+  createLabel: function (feature) {
+    return `${feature.properties.value} %g`;
   }
 
 });

--- a/src/app/shared/map-overlay/shakemap-psa30-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-psa30-overlay.spec.ts
@@ -12,7 +12,7 @@ describe('ShakemapPSA30Overlay', () => {
     geometry: {
       coordinates: [[[0, 0], [1, 1]]]
     }
-  }
+  };
 
   beforeEach(() => {
     overlay = new ShakemapPSA30Overlay(null);
@@ -23,7 +23,7 @@ describe('ShakemapPSA30Overlay', () => {
   });
 
   it('uses product when defined', () => {
-    const overlay = new ShakemapPSA30Overlay({
+    overlay = new ShakemapPSA30Overlay({
       contents: {
         'download/cont_psa30.json': {url: 'URL'}
       }
@@ -38,5 +38,5 @@ describe('ShakemapPSA30Overlay', () => {
     const label = overlay.createLabel(FEATURE);
 
     expect(label).toBeTruthy();
-  })
+  });
 });

--- a/src/app/shared/map-overlay/shakemap-psa30-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-psa30-overlay.spec.ts
@@ -4,6 +4,20 @@ import * as L from 'leaflet';
 
 
 describe('ShakemapPSA30Overlay', () => {
+  let overlay;
+  const FEATURE = {
+    properties: {
+      value: 1
+    },
+    geometry: {
+      coordinates: [[[0, 0], [1, 1]]]
+    }
+  }
+
+  beforeEach(() => {
+    overlay = new ShakemapPSA30Overlay(null);
+  });
+
   it('can be created', () => {
     expect(new ShakemapPSA30Overlay(null)).toBeTruthy();
   });
@@ -20,44 +34,9 @@ describe('ShakemapPSA30Overlay', () => {
     expect(overlay.data).toBe(null);
   });
 
-  describe('style', () => {
-    it('runs', () => {
+  it('creates a label', () => {
+    const label = overlay.createLabel(FEATURE);
 
-      const overlay = new ShakemapPSA30Overlay(null);
-      const style = overlay.style({});
-    });
-
-  });
-
-  describe('onEachFeature', () => {
-    it('generates popup', () => {
-      const feature = {
-        properties: {
-          color: 'COLOR',
-          value: 5
-        }
-      };
-
-      const overlay = new ShakemapPSA30Overlay(null);
-      const layer = new L.Layer();
-
-      overlay.onEachFeature(feature, layer);
-
-      expect(layer._popup).toBeDefined();
-
-    });
-
-    it('ignores object without properties', () => {
-      const feature = {};
-
-      const overlay = new ShakemapPSA30Overlay(null);
-      const layer = new L.Layer();
-
-      overlay.onEachFeature(feature, layer);
-
-      expect(layer._popup).toBeUndefined();
-
-    });
-
-  });
+    expect(label).toBeTruthy();
+  })
 });

--- a/src/app/shared/map-overlay/shakemap-psa30-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-psa30-overlay.ts
@@ -15,6 +15,12 @@ const ShakemapPSA30Overlay = AsynchronousGeoJSONOverlay.extend({
     this.url = this.getUrl(product);
   },
 
+  afterAdd: function () {
+    this.eachLayer((layer) => {
+      layer.openTooltip();
+    });
+  },
+
   getUrl: function (product) {
     if (product == null) {
       return null;
@@ -32,12 +38,6 @@ const ShakemapPSA30Overlay = AsynchronousGeoJSONOverlay.extend({
 
       layer.bindTooltip(t);
     }
-  },
-
-  afterAdd: function () {
-    this.eachLayer((layer) => {
-      layer.openTooltip();
-    });
   },
 
   style: function (feature) {

--- a/src/app/shared/map-overlay/shakemap-psa30-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-psa30-overlay.ts
@@ -1,24 +1,18 @@
 import * as L from 'leaflet';
 
-import { AsynchronousGeoJSONOverlay } from './asynchronous-geojson-overlay';
+import { ShakemapContoursOverlay } from './shakemap-contours-overlay';
 
 
-const ShakemapPSA30Overlay = AsynchronousGeoJSONOverlay.extend({
+const ShakemapPSA30Overlay = ShakemapContoursOverlay.extend({
 
   id: 'shakemap-psa30',
   title: 'Shakemap PSA30 Contours',
   legend: null,
 
   initialize: function (product) {
-    AsynchronousGeoJSONOverlay.prototype.initialize.call(this);
+    ShakemapContoursOverlay.prototype.initialize.call(this);
 
     this.url = this.getUrl(product);
-  },
-
-  afterAdd: function () {
-    this.eachLayer((layer) => {
-      layer.openTooltip();
-    });
   },
 
   getUrl: function (product) {
@@ -30,24 +24,8 @@ const ShakemapPSA30Overlay = AsynchronousGeoJSONOverlay.extend({
          product.contents['download/cont_psa30.json'].url : null;
   },
 
-  onEachFeature: function (feature, layer) {
-    if (feature.properties) {
-      const t = L.tooltip({
-        permanent: true
-      }).setContent(`${feature.properties.value} %g`);
-
-      layer.bindTooltip(t);
-    }
-  },
-
-  style: function (feature) {
-    // set default line style
-    const lineStyle = {
-      'color': '#fff',
-      'opacity': 1
-    };
-
-    return lineStyle;
+  createLabel: function (feature) {
+    return `${feature.properties.value} %g`;
   }
 
 });

--- a/src/app/shared/map-overlay/shakemap-psa30-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-psa30-overlay.ts
@@ -26,8 +26,18 @@ const ShakemapPSA30Overlay = AsynchronousGeoJSONOverlay.extend({
 
   onEachFeature: function (feature, layer) {
     if (feature.properties) {
-      layer.bindPopup(`${feature.properties.value} %g`);
+      const t = L.tooltip({
+        permanent: true
+      }).setContent(`${feature.properties.value} %g`);
+
+      layer.bindTooltip(t);
     }
+  },
+
+  afterAdd: function () {
+    this.eachLayer((layer) => {
+      layer.openTooltip();
+    });
   },
 
   style: function (feature) {

--- a/src/app/shared/shakemap-overlays.pipe.ts
+++ b/src/app/shared/shakemap-overlays.pipe.ts
@@ -17,7 +17,7 @@ import * as L from 'leaflet';
 })
 export class ShakemapOverlaysPipe implements PipeTransform {
 
-  transform (product: any, enabled: string = null): Array<L.Layer> {
+  transform (product: any, enabled: string[] = []): Array<L.Layer> {
     let overlays = [];
 
     if (product) {
@@ -30,7 +30,7 @@ export class ShakemapOverlaysPipe implements PipeTransform {
       overlays.push(new ShakemapStationsOverlay(product));
 
       overlays.forEach((overlay) => {
-        overlay.enabled = overlay.id === enabled;
+        overlay.enabled = enabled.indexOf(overlay.id) > -1;
       });
 
       // filter overlays with missing products

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -20,6 +20,7 @@
 
 @import './app/shared/css/mmi-colors.scss';
 @import './app/shared/css/station-overlay.scss';
+@import './app/shared/css/contour-overlay.scss';
 
 /* allow wrapping on small screens */
 .mat-radio-label-content {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,26 +1,15 @@
 /* You can add global styles to this file, and also import other style files */
-
-
 @import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
 
+@import './app/shared/css/contour-overlay.scss';
 @import './app/shared/css/description-table.scss';
-
-/* Leaflet Styles */
-@mixin leaflet-control () {
-  background: #fff;
-  border: 2px solid rgba(0,0,0,0.2);
-  border-radius: 5px;
-  float: left;
-  margin: 10px;
-  padding: 0;
-}
-
-@import './app/shared/css/leaflet-styles.scss';
-@import './app/shared/map-control/legend-control.scss';
-
 @import './app/shared/css/mmi-colors.scss';
 @import './app/shared/css/station-overlay.scss';
-@import './app/shared/css/contour-overlay.scss';
+
+/* Leaflet Styles */
+@import './app/shared/css/leaflet-styles.scss'; // import before legend-control.scss
+@import './app/shared/map-control/legend-control.scss';
+
 
 /* allow wrapping on small screens */
 .mat-radio-label-content {


### PR DESCRIPTION
fixes #977  

- [X] Add an additional check whether each image exists for static maps/images

- [X] Remove shared-map attribution for the static images

- [X] Using Grayscale baselayer for contour visibility

- [X] Add stations layer to PGA/PGV/PSA static maps
    - [ ] maybe this means there should be an intensity legend for each of these?

- [X] Labeling PGA/PGV/PSA contours:
    - Using divIcon labels that looks similar to old static images
    - Labeling every other contour to avoid clutter
    - Labeling random spot on contour to avoid label collisions (still happens)

- [X] Created `shakemap-contours-overlay` class to avoid duplicating the contour label logic and tests
    - subclassed for PGA/PGV/PSA overlays.

- [X] `afterAdd` method in `asynchronous-map-overlay` class that executes after geoJSON data is added to the layer. In `shakemap-contours-overlay` this is used to set the bounds for the layer and adjust the map. This requires the map to be attached to the overlay...

- [x] Added `map` property to `asynchronous-map-overlay` class to adjust the map bounds after geoJSON data is added


## To Do:
- [ ] Contour labels sometimes hide behind stations
- [ ] Maybe add tooltips to contours as well that will pop up on hover
