### PR TITLE
Issue-990

### DIFF
--- a/src/app/oaf/commentary/commentary.component.html
+++ b/src/app/oaf/commentary/commentary.component.html
@@ -1,7 +1,15 @@
 <ng-container *ngIf="eventService.product$ | async as product; else noProduct">
+  <h4>Product</h4>
   <pre>
     {{ product | json }}
   </pre>
+
+  <ng-container *ngIf="oafService.oaf$ | async as oaf">
+    <h4>Details</h4>
+    <pre>
+      {{ oaf | json }}
+    </pre>
+  </ng-container>
 </ng-container>
 
 <ng-template #noProduct>

--- a/src/app/oaf/commentary/commentary.component.spec.ts
+++ b/src/app/oaf/commentary/commentary.component.spec.ts
@@ -1,8 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs/observable/of';
 
-import { CommentaryComponent } from './commentary.component';
 import { EventService } from '../../core/event.service';
+
+import { OafService } from '../oaf.service';
+
+import { CommentaryComponent } from './commentary.component';
+
 
 
 describe('CommentaryComponent', () => {
@@ -14,12 +18,17 @@ describe('CommentaryComponent', () => {
       product$: of(null)
     };
 
+    const oafServiceStub = {
+      oaf$: of(null)
+    };
+
     TestBed.configureTestingModule({
       declarations: [
         CommentaryComponent
       ],
       providers: [
-        {provide: EventService, useValue: eventServiceStub}
+        {provide: EventService, useValue: eventServiceStub},
+        {provide: OafService, useValue: oafServiceStub}
       ]
     })
     .compileComponents();

--- a/src/app/oaf/commentary/commentary.component.ts
+++ b/src/app/oaf/commentary/commentary.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 import { EventService } from '../../core/event.service';
+import { OafService } from '../oaf.service';
 
 
 @Component({
@@ -8,13 +9,11 @@ import { EventService } from '../../core/event.service';
   templateUrl: './commentary.component.html',
   styleUrls: ['./commentary.component.scss']
 })
-export class CommentaryComponent implements OnInit {
+export class CommentaryComponent {
 
   constructor (
-    public eventService: EventService
+    public eventService: EventService,
+    public oafService: OafService
   ) { }
-
-  ngOnInit () {
-  }
 
 }

--- a/src/app/oaf/model/model.component.html
+++ b/src/app/oaf/model/model.component.html
@@ -1,3 +1,11 @@
-<p>
-  model works!
-</p>
+<ng-container *ngIf="oafService.model$ | async as model">
+  <h3><a href="{{ model.reference }}">{{ model.name }}</a></h3>
+
+  <h4>Parameters</h4>
+  <dl class="description-table">
+    <ng-container *ngFor="let key of model.parameters.keys">
+      <dt>{{ key }}</dt>
+      <dd>{{ model.parameters.values[key] }}</dd>
+    </ng-container>
+  </dl>
+</ng-container>

--- a/src/app/oaf/model/model.component.spec.ts
+++ b/src/app/oaf/model/model.component.spec.ts
@@ -1,4 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs/observable/of';
+
+import { OafService } from '../oaf.service';
 
 import { ModelComponent } from './model.component';
 
@@ -8,8 +11,17 @@ describe('ModelComponent', () => {
   let fixture: ComponentFixture<ModelComponent>;
 
   beforeEach(async(() => {
+    const oafServiceStub = {
+      model$: of(null)
+    };
+
     TestBed.configureTestingModule({
-      declarations: [ ModelComponent ]
+      declarations: [
+        ModelComponent
+      ],
+      providers: [
+        {provide: OafService, useValue: oafServiceStub}
+      ]
     })
     .compileComponents();
   }));

--- a/src/app/oaf/model/model.component.ts
+++ b/src/app/oaf/model/model.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+
+import { OafService } from '../oaf.service';
 
 
 @Component({
@@ -6,11 +8,10 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './model.component.html',
   styleUrls: ['./model.component.scss']
 })
-export class ModelComponent implements OnInit {
+export class ModelComponent {
 
-  constructor () { }
-
-  ngOnInit () {
-  }
+  constructor (
+    public oafService: OafService
+  ) { }
 
 }

--- a/src/app/oaf/oaf.module.ts
+++ b/src/app/oaf/oaf.module.ts
@@ -6,16 +6,15 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { ProductPageModule } from '../product-page/product-page.module';
 import { SharedModule } from '../shared/shared.module';
 
-import { OafRoutingModule } from './oaf-routing.module';
-
 import { CommentaryComponent } from './commentary/commentary.component';
 import { ForecastComponent } from './forecast/forecast.component';
 import { ModelComponent } from './model/model.component';
-import { OafPercentPipe } from './oaf-percent.pipe';
 import { OafComponent } from './oaf/oaf.component';
+import { OafPercentPipe } from './oaf-percent.pipe';
+import { OafRoutingModule } from './oaf-routing.module';
+import { OafService } from './oaf.service';
 import { RoundDownPipe } from './round-down.pipe';
 import { RoundUpPipe } from './round-up.pipe';
-
 
 
 @NgModule({
@@ -29,18 +28,16 @@ import { RoundUpPipe } from './round-up.pipe';
     OafRoutingModule
   ],
   declarations: [
-    OafComponent,
-    OafPercentPipe,
     CommentaryComponent,
     ForecastComponent,
     ModelComponent,
-    RoundDownPipe,
-    RoundUpPipe
-  ],
-  exports: [
+    OafComponent,
     OafPercentPipe,
     RoundDownPipe,
     RoundUpPipe
+  ],
+  providers: [
+    OafService
   ]
 })
 export class OafModule { }

--- a/src/app/oaf/oaf.service.spec.ts
+++ b/src/app/oaf/oaf.service.spec.ts
@@ -1,0 +1,106 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { OafService } from './oaf.service';
+
+describe('OafService', () => {
+  const MODEL = {
+    ref: 'modelRef',
+    name: 'modelName',
+    parameters: {
+      paramOne: 'valueOne',
+      paramTwo: 'valueTwo'
+    }
+  };
+
+  const OAF = {
+    model: MODEL
+  };
+
+  const PRODUCT = {
+    contents: {'': { bytes: JSON.stringify(OAF)}}
+  };
+
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [OafService]
+    });
+  });
+
+  it('should be created', inject([OafService], (service: OafService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  describe('getOaf', () => {
+    it('should tick next of null on errors',
+        inject([OafService], (service: OafService) => {
+      const subscription = service.oaf$.subscribe((value) => {
+        expect(value).toBe(null);
+      });
+      subscription.add(service.model$.subscribe((value) => {
+        expect(value).toBe(null);
+      }));
+
+      service.getOaf(null);
+      service.getOaf('');
+      service.getOaf('{"foo": bar}');
+      service.getOaf(JSON.stringify({
+        contents: {
+          '': {
+            bytes: '{"foo": bar,}' // <-- Intentional syntax error
+          }
+        }
+      }));
+
+      subscription.unsubscribe();
+    }));
+  });
+
+  it('should notify with objects on success',
+        inject([OafService], (service: OafService) => {
+    let triggered = false;
+
+    const parseOafSpy = spyOn(service, 'parseOaf').and.callThrough();
+    const parseModelSpy = spyOn(service, 'parseModel').and.callThrough();
+
+    const subscription = service.oaf$.subscribe((value) => {
+      if (triggered) {
+        expect(value).not.toEqual(null);
+        expect(parseOafSpy).toHaveBeenCalledWith(JSON.stringify(OAF));
+      }
+    });
+
+    subscription.add(service.model$.subscribe((value) => {
+      if (triggered) {
+        expect(value).not.toEqual(null);
+        expect(parseModelSpy).toHaveBeenCalledWith(MODEL);
+      }
+    }));
+
+    triggered = true;
+    service.getOaf(PRODUCT);
+
+    subscription.unsubscribe();
+  }));
+
+  describe('parseModel', () => {
+    it('parses correctly', inject([OafService], (service: OafService) => {
+      expect(service.parseModel(MODEL)).toEqual({
+        ref: MODEL.ref,
+        name: MODEL.name,
+        parameters: {
+          keys: Object.keys(MODEL.parameters),
+          values: MODEL.parameters
+        }
+      });
+    }));
+  });
+
+  describe('parseOaf', () => {
+    it('defers to JSON.parse', inject([OafService], (service: OafService) => {
+      const jsonSpy = spyOn(JSON, 'parse');
+      service.parseOaf('');
+      expect(jsonSpy).toHaveBeenCalledWith('');
+    }));
+  })
+});

--- a/src/app/oaf/oaf.service.spec.ts
+++ b/src/app/oaf/oaf.service.spec.ts
@@ -102,5 +102,5 @@ describe('OafService', () => {
       service.parseOaf('');
       expect(jsonSpy).toHaveBeenCalledWith('');
     }));
-  })
+  });
 });

--- a/src/app/oaf/oaf.service.ts
+++ b/src/app/oaf/oaf.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+
+
+@Injectable()
+export class OafService {
+
+  public oaf$: BehaviorSubject<any> = new BehaviorSubject<any>(null);
+  public model$: BehaviorSubject<any> = new BehaviorSubject<any>(null);
+
+  constructor () { }
+
+  getOaf (product: any): void {
+    try {
+      const bytes = product.contents[''].bytes;
+      const oaf = this.parseOaf(bytes);
+      const model = this.parseModel(oaf.model);
+
+      this.oaf$.next(oaf);
+      this.model$.next(model);
+    } catch (e) {
+      this.oaf$.next(null);
+      this.model$.next(null);
+    }
+  }
+
+  parseModel (model: any): any {
+    return {
+      ref: model.ref,
+      name: model.name,
+      parameters: {
+        keys: Object.keys(model.parameters),
+        values: model.parameters
+      }
+    };
+  }
+
+  parseOaf (bytes: any): any {
+    return JSON.parse(bytes);
+  }
+}

--- a/src/app/oaf/oaf/oaf.component.spec.ts
+++ b/src/app/oaf/oaf/oaf.component.spec.ts
@@ -1,9 +1,13 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs/observable/of';
+import { MockComponent } from 'ng2-mock-component';
+
+import { EventService } from '../../core/event.service';
+import { OafService } from '../oaf.service';
 
 import { OafComponent } from './oaf.component';
-import { MockComponent } from 'ng2-mock-component';
 
 
 describe('OafComponent', () => {
@@ -11,6 +15,13 @@ describe('OafComponent', () => {
   let fixture: ComponentFixture<OafComponent>;
 
   beforeEach(async(() => {
+    const eventServiceStub = {
+      product$: of(null)
+    };
+    const oafServiceStub = {
+      getOaf: (product: any) => null
+    };
+
     TestBed.configureTestingModule({
       declarations: [
         OafComponent,
@@ -20,6 +31,10 @@ describe('OafComponent', () => {
       imports: [
         MatTabsModule,
         RouterTestingModule
+      ],
+      providers: [
+        {provide: EventService, useValue: eventServiceStub},
+        {provide: OafService, useValue: oafServiceStub}
       ]
     })
     .compileComponents();
@@ -33,5 +48,21 @@ describe('OafComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('onProduct', () => {
+    it('guards against non-oaf products', () => {
+      const getOafSpy = spyOn(component.oafService, 'getOaf');
+      const oafProduct = {type: 'oaf'};
+
+      component.onProduct(null);
+      component.onProduct({});
+      component.onProduct({type: 'not-an-oaf'});
+
+      expect(getOafSpy).not.toHaveBeenCalled();
+
+      component.onProduct(oafProduct);
+      expect(getOafSpy).toHaveBeenCalledWith(oafProduct);
+    });
   });
 });

--- a/src/app/oaf/oaf/oaf.component.ts
+++ b/src/app/oaf/oaf/oaf.component.ts
@@ -1,15 +1,39 @@
-import { Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy } from '@angular/core';
+
+import { Subscription } from 'rxjs/Subscription';
+
+import { EventService } from '../../core/event.service';
+import { OafService } from '../oaf.service';
+
 
 @Component({
   selector: 'oaf',
   templateUrl: './oaf.component.html',
   styleUrls: ['./oaf.component.scss']
 })
-export class OafComponent implements OnInit {
+export class OafComponent implements AfterViewInit, OnDestroy {
 
-  constructor () { }
+  private subscription: Subscription = new Subscription();
 
-  ngOnInit () {
+  constructor (
+    public eventService: EventService,
+    public oafService: OafService
+  ) { }
+
+  ngAfterViewInit () {
+    this.subscription.add(this.eventService.product$.subscribe((product) => {
+      return this.onProduct(product);
+    }));
+  }
+
+  ngOnDestroy () {
+    this.subscription.unsubscribe();
+  }
+
+  onProduct (product: any): void {
+    if (product && product.type === 'oaf') {
+      this.oafService.getOaf(product);
+    }
   }
 
 }


### PR DESCRIPTION
fixes #990
fixes #993 

Service could be expanded if custom parsing is necessary for a specific tab (similar to what was done for model details tab).

Potentially could restructure how products are sent from OAF back-end to match the parsed data structure.

Potentially can send product files as attachments rather than inline content. Service can then be updated to download files rather than simply parse byte content.

For now, it works and positions the code well for future development.