### PR TITLE
Patch Forecast Rendering

### DIFF
--- a/src/app/oaf/commentary/commentary.component.ts
+++ b/src/app/oaf/commentary/commentary.component.ts
@@ -63,6 +63,7 @@ export class CommentaryComponent implements OnDestroy, OnInit {
     for (let i = 0, len = forecasts.length; i < len; i++) {
       forecast = forecasts[i];
       if (forecast.label === timeframe) {
+        forecast = JSON.parse(JSON.stringify(forecast));
         break;
       }
     }


### PR DESCRIPTION
Fix commentary tab to not modify the shared forecast for its own purpose.

This is a quick fix but we may need larger refactoring.