### PR TITLE
Issue-1232

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,6 +36,9 @@ location  /${BASE_HREF}  {
   add_header  'X-Content-Type-Options'  'nosniff';
   add_header  'X-XSS-Protection'  '1; mode=block';
 
+  expires 15m;
+  add_header 'Cache-Control' 'public';
+
   try_files \$uri \$uri/ \$uri.html \$uri/index.html @angular-fallback;
 }
 


### PR DESCRIPTION
Fixes #1232

To verify ...
- Pull in PR changes
- Build image
```
$ docker build -t local/earthquake-eventpages:latest .
```
- Start container
```
$ docker run --name test-eventpages --rm -p 8080:80 -e BASE_HREF=earthquakes/eventpage local/earthquake-eventpages:latest
```
- Load event page http://localhost:8080/earthquakes/eventpage/ci38245496/executive
- Inspect network tab / headers.

**Verify**
- All resources served from cache (so long as caching not disabled by browser and not hard refreshed). 
- Should have header: "Cache-Control" "public"
- Should have header: "Cache-Control" "max-age=900"
- Most resources should indicate "served from memory cache" or "served from disk cache"