### PR TITLE
Fixed metadata date issue

### DIFF
--- a/src/app/shared/date-time.pipe.ts
+++ b/src/app/shared/date-time.pipe.ts
@@ -18,7 +18,7 @@ export class DateTimePipe implements PipeTransform {
    *     formatted date/time string
    */
   transform(time: any): string {
-    let date = new Date(parseFloat(time));
+    let date = new Date(time);
 
     // check for valid date
     if (isNaN(date.getTime())) {

--- a/src/app/shared/date-time.pipe.ts
+++ b/src/app/shared/date-time.pipe.ts
@@ -21,7 +21,7 @@ export class DateTimePipe implements PipeTransform {
     let date = new Date(time);
 
     // check for valid date
-    if (isNaN(date.getTime())) {
+    if (isNaN(date.getTime()) || (!time && time !== 0)) {
       date = null;
     }
 


### PR DESCRIPTION
Closes #1272 

Stopped pre-parsing input dates and let the Date object take care of it. This will fail for string epoch dates (which we aren't ever passing it as far as I can tell), but gets the correct dates for ShakeMap and OAF data formats which appear to be the only modules using this pipe