### PR TITLE
Additional tests and doc string for sharedDateTime pipe

### DIFF
--- a/src/app/shared/date-time.pipe.spec.ts
+++ b/src/app/shared/date-time.pipe.spec.ts
@@ -1,12 +1,11 @@
 import { DateTimePipe } from './date-time.pipe';
+import { FormatterService } from '@core/formatter.service';
 
 describe('DateTimePipe', () => {
   let formatterService, pipe;
 
   beforeEach(() => {
-    formatterService = {
-      dateTime: jasmine.createSpy('dateTime spy')
-    };
+    formatterService = new FormatterService();
 
     pipe = new DateTimePipe(formatterService);
   });
@@ -16,14 +15,44 @@ describe('DateTimePipe', () => {
   });
 
   it('transforms good time', () => {
+    spyOn(formatterService, 'dateTime');
     pipe.transform(0);
     expect(formatterService.dateTime).toHaveBeenCalled();
     expect(formatterService.dateTime).toHaveBeenCalledWith(new Date(0));
   });
 
   it('transforms no time', () => {
+    spyOn(formatterService, 'dateTime');
     pipe.transform(null);
     expect(formatterService.dateTime).toHaveBeenCalled();
     expect(formatterService.dateTime).toHaveBeenCalledWith(null);
+  });
+
+  it('transforms timestamp', () => {
+    const time = '2012-09-05T14:42:07Z';
+    const timeCheck = '2012-09-05 14:42:07 (UTC)';
+    const transTime = pipe.transform(time);
+    expect(transTime).toBe(timeCheck);
+  });
+
+  it('transforms ms since epoch', () => {
+    const time = 1535676099824;
+    const timeCheck = '2018-08-31 00:41:39 (UTC)';
+    const transTime = pipe.transform(time);
+    expect(transTime).toBe(timeCheck);
+  });
+
+  it('gracefully ignores string epoch', () => {
+    const time = '1535676099824';
+    const timeCheck = '-';
+    const transTime = pipe.transform(time);
+    expect(transTime).toBe(timeCheck);
+  });
+
+  it('gracefully ignores non-timestamp string', () => {
+    const time = 'bad timestamp';
+    const timeCheck = '-';
+    const transTime = pipe.transform(time);
+    expect(transTime).toBe(timeCheck);
   });
 });

--- a/src/app/shared/date-time.pipe.ts
+++ b/src/app/shared/date-time.pipe.ts
@@ -12,10 +12,11 @@ export class DateTimePipe implements PipeTransform {
    * Format dateTime object based on a time input
    *
    * @param time
-   *     Time input
+   *     Time to be transformed into a timestamp. Must be a format readable
+   *     by the Date JavaScript object
    *
    * @return {string}
-   *     formatted date/time string
+   *     formatted date/time string. Ex: '2018-08-31 23:05:43 (UTC)'
    */
   transform(time: any): string {
     let date = new Date(time);


### PR DESCRIPTION
closes #1272 

Added tests to ensure milliseconds since epoch and string timestamps can be read and transformed correctly. Also testing some graceful handling of non-supported input types