### PR TITLE
Issue 1321

### DIFF
--- a/src/app/executive/executive/executive.component.html
+++ b/src/app/executive/executive/executive.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="eventService.event$ | async; let event">
-  <shared-text-product
-      *ngFor="let product of event.getProducts('general-header');
-          trackBy: trackByIndex" [product]="product">
+  <shared-text-product *ngFor="let product of event.getProducts('general-header');
+          trackBy: trackByIndex"
+    [product]="product">
   </shared-text-product>
 
   <ul class="pins">
@@ -73,15 +73,15 @@
     </li>
 
     <li *ngIf="event | nearbySeismicityLink: 'nearby'; let link">
-      <executive-nearby-seismicity-pin [event]="event" [link]="link">
+      <executive-nearby-seismicity-pin [event]="event"
+        [link]="link">
       </executive-nearby-seismicity-pin>
     </li>
   </ul>
 
-  <shared-text-product
-      *ngFor="let product of event.getProducts('general-text');
+  <shared-text-product *ngFor="let product of event.getProducts('general-text');
           trackBy: trackByIndex"
-      [product]="product">
+    [product]="product">
   </shared-text-product>
 
   <ng-container *ngIf="event.hasProducts('general-link')">

--- a/src/app/executive/finite-fault-pin/finite-fault-pin.component.html
+++ b/src/app/executive/finite-fault-pin/finite-fault-pin.component.html
@@ -1,14 +1,14 @@
-<basic-pin
-    [link]="link"
-    [product]="product"
-    [title]="title">
+<basic-pin [link]="link"
+  [product]="product"
+  [title]="title">
 
   <figure *ngIf="product |
       sharedProductContent
-          :'cross-section.png'
+          :'slip.png'
           :('web/' + product?.properties?.eventsourcecode + '_slip2.png');
       let content; else noContent">
-    <img src="{{ content.url }}" alt="Cross-section of slip distribution"/>
+    <img src="{{ content.url }}"
+      alt="Cross-section of slip distribution" />
     <figcaption>
       Cross-section of slip distribution.
     </figcaption>

--- a/src/app/finite-fault/finite-fault/finite-fault.component.html
+++ b/src/app/finite-fault/finite-fault/finite-fault.component.html
@@ -74,7 +74,7 @@
     <figure *ngIf="product |
         sharedProductContent
           :'slip.png'
-          :('web/' + product | sharedProductProperty:'eventsourcecode' +
+          :('web/' + product?.properties?.eventsourcecode +
           '_slip2.png')
           as content">
       <img src="{{ content.url }}"
@@ -94,7 +94,7 @@
     <figure *ngIf="product |
         sharedProductContent
           :'basemap.png'
-          :('web/' + product | sharedProductProperty:'eventsourcecode' +
+          :('web/' + product?.properties?.eventsourcecode +
           '_basemap.png')
           as content">
       <img src="{{ content.url }}"


### PR DESCRIPTION
fixes #1321 

Updated Finite fault pin logic and logic in the finite-fault.component. The fall backs where not working correctly because of the sharedProductProperties pipe. Appending to them caused a null value to return. After spending quite some time on this problem I was unable to find a solution. Perhaps creating a new pipe to handle the formatting better? I don't see this being a problem anywhere else other than finite fault and the backups should be going away in the long term? Also the reason for creating the sharedProductProperties pipe in the first place is not an issue here as the elvis operator can be used.
