### PR TITLE
Show file extensions in download view, instead of mime-types

### DIFF
--- a/src/app/product-page/download-item/download-item.component.html
+++ b/src/app/product-page/download-item/download-item.component.html
@@ -4,7 +4,7 @@
   <ul class="formats">
     <li *ngFor="let format of item.formats;trackBy: trackByIndex">
       <a href="{{ format.url }}">
-        {{ format.type | uppercase }}
+        {{ format.href | fileExtension | uppercase }}
         {{ format.length | fileSize }}
       </a>
     </li>

--- a/src/app/product-page/download-item/download-item.component.spec.ts
+++ b/src/app/product-page/download-item/download-item.component.spec.ts
@@ -12,6 +12,7 @@ describe('DownloadItemComponent', () => {
       declarations: [
         DownloadItemComponent,
 
+        MockPipe('fileExtension'),
         MockPipe('fileSize')
       ]
     })

--- a/src/app/product-page/file-extension.pipe.spec.ts
+++ b/src/app/product-page/file-extension.pipe.spec.ts
@@ -1,0 +1,25 @@
+import { FileExtensionPipe } from './file-extension.pipe';
+
+describe('FileExtensionPipe', () => {
+  let pipe;
+
+  beforeEach(() => {
+    pipe = new FileExtensionPipe();
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  describe('transform', () => {
+    it('formats properly', () => {
+      const result = pipe.transform('folder/file.extension');
+      expect(result).toBe('extension');
+    });
+
+    it('handles empty paths', () => {
+      const result = pipe.transform('');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/app/product-page/file-extension.pipe.ts
+++ b/src/app/product-page/file-extension.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'fileExtension'
+})
+export class FileExtensionPipe implements PipeTransform {
+  transform(path: string): string {
+    if (!path) {
+        return null;
+    }
+
+    // split path on "/", keeping everything after
+    const file = path.split('/').pop();
+    // split file on ".", keeping everything after
+    const extension = file.split('.').pop();
+
+    return extension;
+  }
+}

--- a/src/app/product-page/product-page.module.ts
+++ b/src/app/product-page/product-page.module.ts
@@ -10,12 +10,14 @@ import { FileSizePipe } from './file-size.pipe';
 import { FooterComponent } from './footer/footer.component';
 import { HeaderComponent } from './header/header.component';
 import { ProductPageComponent } from './product-page/product-page.component';
+import { FileExtensionPipe } from './file-extension.pipe';
 
 @NgModule({
   declarations: [
     DateTimePipe,
     DownloadComponent,
     DownloadItemComponent,
+    FileExtensionPipe,
     FileSizePipe,
     FooterComponent,
     HeaderComponent,


### PR DESCRIPTION
@ghayes-usgs pointed out that we were showing mime types instead of file extensions, different from the production pages.  I agree that file extensions are less cryptic than mime-types for most users.