### PR TITLE
Increment hazdev-ng-geoserve-output dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "core-js": "^2.5.6",
     "d3": "^5.4.0",
     "document-register-element": "1.8.1",
-    "hazdev-ng-geoserve-output": "0.0.3",
+    "hazdev-ng-geoserve-output": "0.1.0",
     "hazdev-ng-location-view": "0.0.4",
     "hazdev-ng-template": "0.1.0",
     "leaflet": "^1.3.1",


### PR DESCRIPTION
fixes #1323 

Update geoserve output to fix tectonic summary images