### PR TITLE
Shakemap overlays update

### DIFF
--- a/src/app/shakemap/psa/psa.component.html
+++ b/src/app/shakemap/psa/psa.component.html
@@ -3,7 +3,8 @@
   <h3>Peak Spectral Acceleration for 0.3 s, 1.0 s, 3.0 s</h3>
 
   <ng-container
-      *ngIf="shakemap?.contents['download/cont_psa03.json']; else noPSA03">
+      *ngIf="shakemap | sharedProductContent:
+      'download/cont_psa03.json':'download/cont_psa0p3.json'; else noPSA03">
     <h4>0.3 s PSA (%g)</h4>
     <a [routerLink]="'../../map'"
        [queryParams]="{
@@ -36,7 +37,8 @@
   </ng-template>
 
   <ng-container
-      *ngIf="shakemap?.contents['download/cont_psa10.json']; else noPSA10">
+      *ngIf="shakemap | sharedProductContent:
+      'download/cont_psa10.json':'download/cont_psa1p0.json'; else noPSA10">
     <h4>1.0 s PSA (%g)</h4>
     <a [routerLink]="'../../map'"
         [queryParams]="{
@@ -69,7 +71,8 @@
   </ng-template>
 
   <ng-container
-      *ngIf="shakemap?.contents['download/cont_psa30.json']; else noPSA30">
+      *ngIf="shakemap | sharedProductContent:
+      'download/cont_psa30.json':'download/cont_psa3p0.json'; else noPSA30">
     <h4>3.0 s PSA (%g)</h4>
     <a [routerLink]="'../../map'"
        [queryParams]="{

--- a/src/app/shakemap/psa/psa.component.spec.ts
+++ b/src/app/shakemap/psa/psa.component.spec.ts
@@ -33,7 +33,8 @@ describe('PsaComponent', () => {
           selector: 'shared-map'
         }),
 
-        MockPipe('shakemapOverlays')
+        MockPipe('shakemapOverlays'),
+        MockPipe('sharedProductContent')
       ],
       imports: [RouterTestingModule],
       providers: [{ provide: EventService, useValue: eventServiceStub }]

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.spec.ts
@@ -64,6 +64,40 @@ describe('ShakemapContoursOverlay', () => {
     });
   });
 
+  describe('style', () => {
+    it('uses weight property when available', () => {
+      const shakemapV4Feature = {
+        geometry: {
+          coordinates: [[[0, 0], [1, 1]]]
+        },
+        properties: {
+          color: '#aaa',
+          value: 1,
+          weight: 4
+        }
+      };
+
+      const style = overlay.style(shakemapV4Feature);
+      expect(style.weight).toBe(shakemapV4Feature.properties.weight);
+    });
+
+    it('uses color property when available', () => {
+      const shakemapV4Feature = {
+        geometry: {
+          coordinates: [[[0, 0], [1, 1]]]
+        },
+        properties: {
+          color: '#aaa',
+          value: 1,
+          weight: 4
+        }
+      };
+
+      const style = overlay.style(shakemapV4Feature);
+      expect(style.color).toBe(shakemapV4Feature.properties.color);
+    });
+  });
+
   describe('after add', () => {
     beforeEach(() => {
       overlay.map = {

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.ts
@@ -78,7 +78,7 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
    * @param feature
    *     The feature from the product
    */
-  getPopupContent: function(feature: any) {
+  generatePopupContent: function(feature: any) {
     return this.createLabel(feature);
   },
 
@@ -122,7 +122,7 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
 
     this._count += 1;
 
-    const popupContent = this.getPopupContent(feature);
+    const popupContent = this.generatePopupContent(feature);
     layer.bindPopup(popupContent);
   },
 
@@ -136,8 +136,7 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
     // set default line style
     // weight oscillates
     const color = feature.properties.color ? feature.properties.color : '#fff';
-    const weight = feature.properties.weight ?
-        feature.properties.weight :  4 - (this._count % 2) * 2;
+    const weight = feature.properties.weight ? feature.properties.weight : 4;
 
     const lineStyle = {
       color: color,

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.ts
@@ -128,7 +128,7 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
     const lineStyle = {
       color: color,
       opacity: 1,
-      weight:  weight
+      weight: weight
     };
 
     return lineStyle;

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.ts
@@ -71,6 +71,17 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
     return angle;
   },
 
+
+  /**
+   * Generates popup content for an individual feature
+   *
+   * @param feature
+   *     The feature from the product
+   */
+  getPopupContent: function(feature: any) {
+    return this.createLabel(feature);
+  },
+
   /**
    * Generates a marker for the contours overlay and adds the layer
    *
@@ -110,6 +121,9 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
     }
 
     this._count += 1;
+
+    const popupContent = this.getPopupContent(feature);
+    layer.bindPopup(popupContent);
   },
 
   /**

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.ts
@@ -19,14 +19,18 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
    *     The product from this event
    */
   initialize: function(product: any) {
-    const legend = document.createElement('img');
-    legend.src = './assets/legend-intensity-contour.png';
-    legend.setAttribute('alt', 'Intensity Contour Legend');
+    AsynchronousGeoJSONOverlay.prototype.initialize.call(this);
+
+    const contourLegend = document.createElement('img');
+    contourLegend.src = './assets/legend-intensity-contour.png';
+    contourLegend.setAttribute('alt', 'Intensity Contour Legend');
+
+    const intensityLegend = document.createElement('img');
+    intensityLegend.src = './assets/shakemap-intensity-legend-small.png';
+    intensityLegend.setAttribute('alt', 'Intensity Scale legend');
 
     // Add to legends array
-    this.legends.push(legend);
-
-    AsynchronousGeoJSONOverlay.prototype.initialize.call(this);
+    this.legends.push(intensityLegend, contourLegend);
   },
 
   /**
@@ -117,10 +121,14 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
   style: function(feature: any) {
     // set default line style
     // weight oscillates
+    const color = feature.properties.color ? feature.properties.color : '#fff';
+    const weight = feature.properties.weight ?
+        feature.properties.weight :  4 - (this._count % 2) * 2;
+
     const lineStyle = {
-      color: '#fff',
+      color: color,
       opacity: 1,
-      weight: 4 - (this._count % 2) * 2
+      weight:  weight
     };
 
     return lineStyle;


### PR DESCRIPTION
closes #1199 
closes #1315

Using Shakemap v4 products in PSA tab
Using weight and color properties when available, added intensity legend, and added popup content for PGA/PGV/PSA contours