### PR TITLE
DYFI Intensity Vs. Distance plot update

### DIFF
--- a/src/app/dyfi/dyfi.service.ts
+++ b/src/app/dyfi/dyfi.service.ts
@@ -127,8 +127,7 @@ export class DyfiService {
         ngxData = {
           name: data.x,
           value: data.y,
-          x: data.x,
-          y: data.y
+          ...data
         };
 
         if (data.stdev) {

--- a/src/app/dyfi/intensity-vs-distance/intensity-vs-distance.component.html
+++ b/src/app/dyfi/intensity-vs-distance/intensity-vs-distance.component.html
@@ -25,7 +25,8 @@
         [xAxisTicks]="xAxisTicks"
         [xScaleMax]="xScaleMax"
         [xScaleMin]="xScaleMin"
-        [yAxisLabel]="yAxisLabel">
+        [yAxisLabel]="yAxisLabel"
+        [bubbleTooltipTemplate]="meanTemplate">
     </bubble-line-chart-component>
   </div>
 </ng-container>
@@ -45,3 +46,14 @@
     <h1>Not available for this event</h1>
   </ng-template>
 </ng-template>
+
+<ng-template #meanTemplate let-model="model">
+    <h3>{{ model.series }}</h3>
+    <dl class="description-table">
+      <dt>Intensity (mmi): </dt><dd>{{ model.value }}</dd>
+      <dt>Hypocentral Distance (km): </dt><dd>{{ model.x }}</dd>
+      <ng-container *ngIf="model?.nresp">
+        <dt>Number of Responses: </dt><dd>{{ model.nresp | sharedNumber }}</dd>
+      </ng-container>
+    </dl>
+  </ng-template>

--- a/src/app/dyfi/intensity-vs-distance/intensity-vs-distance.component.spec.ts
+++ b/src/app/dyfi/intensity-vs-distance/intensity-vs-distance.component.spec.ts
@@ -71,6 +71,7 @@ describe('IntensityVsDistanceComponent', () => {
               'customColors',
               'results',
               'animations',
+              'bubbleTooltipTemplate',
               'lineChart',
               'lineChartTooltip',
               'bubbleChart',
@@ -97,7 +98,8 @@ describe('IntensityVsDistanceComponent', () => {
           }
         ),
 
-        MockPipe('sharedProductContent')
+        MockPipe('sharedProductContent'),
+        MockPipe('sharedNumber')
       ],
       providers: [
         { provide: EventService, useValue: eventServiceStub },

--- a/src/app/dyfi/intensity-vs-distance/intensity-vs-distance.component.spec.ts
+++ b/src/app/dyfi/intensity-vs-distance/intensity-vs-distance.component.spec.ts
@@ -31,7 +31,9 @@ describe('IntensityVsDistanceComponent', () => {
         {
           class: 'scatterplot1',
           name: 'All reported data',
-          series: []
+          series: [
+            {nresp: 5}
+          ]
         },
         {
           class: 'estimated1',

--- a/src/app/dyfi/intensity-vs-distance/intensity-vs-distance.component.ts
+++ b/src/app/dyfi/intensity-vs-distance/intensity-vs-distance.component.ts
@@ -128,6 +128,17 @@ export class IntensityVsDistanceComponent implements OnInit, OnDestroy {
         });
       }
 
+      // add opacity if features have nresp
+      if (series.series.length > 0 && series.series[0].nresp) {
+        series.series = series.series.map(data => {
+          let opacity = 1;
+          if (data.nresp) {
+            opacity = data.nresp > 5 ? 1 : .2;
+          }
+          return {...data, opacity: opacity};
+        });
+      }
+
       if (options.type === 'line') {
         lineSeries.push(series);
       } else {

--- a/src/app/shared/ngx-charts/bubble-chart/bubble-series/bubble-series.component.ts
+++ b/src/app/shared/ngx-charts/bubble-chart/bubble-series/bubble-series.component.ts
@@ -81,11 +81,10 @@ export class BubbleSeriesComponent extends SwimlaneBubbleSeries {
         const errorBarWidth = (this.xDomain[1] - this.xDomain[0]) * 0.0125;
 
         const data = {
-          name: d.name,
           radius: d.r,
           series: seriesName,
           value: d.y,
-          x: d.x
+          ...d
         };
 
         return {

--- a/src/app/shared/ngx-charts/bubble-chart/bubble-series/bubble-series.component.ts
+++ b/src/app/shared/ngx-charts/bubble-chart/bubble-series/bubble-series.component.ts
@@ -71,7 +71,11 @@ export class BubbleSeriesComponent extends SwimlaneBubbleSeries {
             ? this.colors.getColor(r)
             : this.colors.getColor(seriesName);
 
-        const opacity = isActive ? 1 : 0.3;
+        if (!d.opacity) {
+          d.opacity = 1;
+        }
+
+        const opacity = isActive ? d.opacity : d.opacity / 3;
 
         // error bar calculations
         const max = d.max;

--- a/src/app/shared/ngx-charts/bubble-line-chart/bubble-line-chart/bubble-line-chart.component.html
+++ b/src/app/shared/ngx-charts/bubble-line-chart/bubble-line-chart/bubble-line-chart.component.html
@@ -47,7 +47,7 @@
             [data]="series"
             [activeEntries]="activeEntries"
             [tooltipDisabled]="!bubbleChartTooltip"
-            [tooltipTemplate]="meanTemplate"
+            [tooltipTemplate]="bubbleTooltipTemplate"
             (select)="onClick($event, series)"
             (activate)="onActivate($event)"
             (deactivate)="onDeactivate($event)" />
@@ -93,12 +93,4 @@
           (deactivate)="onDeactivate($event)" />
     </svg:g>
   </svg:g>
-
-  <ng-template #meanTemplate let-model="model">
-    <h3>{{ model.series }}</h3>
-    <dl class="description-table">
-      <dt>Intensity (mmi): </dt><dd>{{ model.value }}</dd>
-      <dt>Hypocentral Distance (km): </dt><dd>{{ model.x }}</dd>
-    </dl>
-  </ng-template>
 </ngx-charts-chart>

--- a/src/app/shared/ngx-charts/bubble-line-chart/bubble-line-chart/bubble-line-chart.component.ts
+++ b/src/app/shared/ngx-charts/bubble-line-chart/bubble-line-chart/bubble-line-chart.component.ts
@@ -151,6 +151,8 @@ export class BubbleLineChartComponent extends BaseChartComponent {
   @Input()
   tooltipDisabled = false;
   @Input()
+  bubbleTooltipTemplate = null;
+  @Input()
   xAxis;
   @Input()
   xAxisLabel;


### PR DESCRIPTION
closes #1197 

Added number of responses to the popup tooltip when available
Scaling transparency with nresp when available
Plotting the IPE lines above the user entry points

It's a little hard to test... but the sample data is [here](https://github.com/usgs/earthquake-eventpages/files/2425318/dyfi_plot_atten.json.txt). Copy and paste that in place of the `response` in the dyfiService's getPlotAtten function [here](https://github.com/usgs/earthquake-eventpages/blob/e0d609fec0634be42d17100b2ebfe7b4040dd200/src/app/dyfi/dyfi.service.ts#L38) to see the new tooltips and scaling