### PR TITLE
Shakemap metadata update

### DIFF
--- a/src/app/shakemap/metadata/processing/processing.component.html
+++ b/src/app/shakemap/metadata/processing/processing.component.html
@@ -183,6 +183,66 @@
     </ng-template>
   </mat-expansion-panel>
 
+  <mat-expansion-panel
+      *ngIf="smProcessing?.shakemap_versions?.map_data_history as history">
+    <mat-expansion-panel-header>
+      <mat-panel-title>
+        Version History
+      </mat-panel-title>
+    </mat-expansion-panel-header>
+
+    <ng-template matExpansionPanelContent>
+      <div class="horizontal-scrolling">
+        <mat-table [dataSource]="history">
+          <mat-header-row *matHeaderRowDef="headers?.history"></mat-header-row>
+          <mat-row *matRowDef="let myRowData; columns: headers?.history"></mat-row>
+
+          <ng-container matColumnDef="version">
+            <mat-header-cell *matHeaderCellDef>
+              Map Version
+            </mat-header-cell>
+            <mat-cell [attr.role]="'rowheader'"
+              [class.mat-cell]="false"
+              class="mat-header-cell"
+              *matCellDef="let version">
+              {{ version[2] }}
+            </mat-cell>
+
+          </ng-container>
+
+          <ng-container matColumnDef="network">
+            <mat-header-cell *matHeaderCellDef>
+              Network
+            </mat-header-cell>
+            <mat-cell *matCellDef="let version">
+              {{ version[1] }}
+            </mat-cell>
+          </ng-container>
+
+          <ng-container matColumnDef="time">
+            <mat-header-cell *matHeaderCellDef>
+              Processing Time
+            </mat-header-cell>
+            <mat-cell *matCellDef="let version">
+              {{ version[0] | sharedDateTime }}
+            </mat-cell>
+          </ng-container>
+
+          <ng-container matColumnDef="comment">
+              <mat-header-cell *matHeaderCellDef>
+                Comment
+              </mat-header-cell>
+              <mat-cell *matCellDef="let version">
+                {{ version[3] }}
+              </mat-cell>
+            </ng-container>
+
+        </mat-table>
+      </div>
+
+    </ng-template>
+  </mat-expansion-panel>
+
   <mat-expansion-panel>
     <mat-expansion-panel-header>
       <mat-panel-title>
@@ -210,7 +270,7 @@
     </ng-template>
   </mat-expansion-panel>
 
-  <mat-expansion-panel>
+  <mat-expansion-panel *ngIf="smProcessing.roi as roi">
     <mat-expansion-panel-header>
       <mat-panel-title>
         ROI
@@ -219,7 +279,7 @@
 
     <ng-template matExpansionPanelContent>
       <div class="horizontal-scrolling">
-        <mat-table [dataSource]="smProcessing?.roi"
+        <mat-table [dataSource]="roi"
           class="roi-table">
           <mat-header-row *matHeaderRowDef="headers?.roi"></mat-header-row>
           <mat-row *matRowDef="let myRowData; columns: headers?.roi"></mat-row>

--- a/src/app/shakemap/metadata/processing/processing.component.html
+++ b/src/app/shakemap/metadata/processing/processing.component.html
@@ -207,7 +207,6 @@
               *matCellDef="let version">
               {{ version[2] }}
             </mat-cell>
-
           </ng-container>
 
           <ng-container matColumnDef="network">

--- a/src/app/shakemap/metadata/processing/processing.component.ts
+++ b/src/app/shakemap/metadata/processing/processing.component.ts
@@ -26,6 +26,7 @@ export class ProcessingComponent {
   };
   readonly headers = {
     groundMotionModules: ['type', 'module', 'reference'],
+    history: ['version', 'network', 'time', 'comment'],
     roi: ['type', 'roi', 'observation_decay']
   };
   readonly names = {

--- a/src/app/shared/units.pipe.spec.ts
+++ b/src/app/shared/units.pipe.spec.ts
@@ -42,6 +42,7 @@ describe('UnitsPipe', () => {
 
   it('calls formatterService for degrees', () => {
     pipe.transform('value', 'degrees');
-    expect(formatter.number).toHaveBeenCalledWith('value', 0, 'default empty');
+    expect(formatter.number)
+        .toHaveBeenCalledWith('value', null, 'default empty');
   });
 });

--- a/src/app/shared/units.pipe.ts
+++ b/src/app/shared/units.pipe.ts
@@ -20,7 +20,10 @@ export class UnitsPipe implements PipeTransform {
    * @return { String | null }
    *     number with units
    */
-  transform(value: number | string, units: string): string | null {
+  transform(
+      value: number | string,
+      units: string,
+      decimals: number = null): string | null {
     let output: string = null;
 
     if (value === null) {
@@ -35,7 +38,7 @@ export class UnitsPipe implements PipeTransform {
 
       case 'degrees': {
         const degPipe = new DegreesPipe(this.formatterService);
-        output = degPipe.transform(value);
+        output = degPipe.transform(value, decimals);
         break;
       }
 


### PR DESCRIPTION
closes #1387 

Hide ROI when the data isn't present
Stop rounding degrees by default in the sharedUnits pipe
Add version history (new in Shakemap v4)