### PR TITLE
Shakemap bounds and basemaps

### DIFF
--- a/src/app/shakemap/intensity/intensity.component.html
+++ b/src/app/shakemap/intensity/intensity.component.html
@@ -10,8 +10,12 @@
          }">
       <shared-map [overlays]="shakemap | shakemapOverlays:['shakemap-intensity',
           'shakemap-stations']"
-        [showScaleControl]="true"
-        [showAttributionControl]="false">
+          [showScaleControl]="true"
+          [showAttributionControl]="false"
+          [bounds]="[[shakemap.properties['maximum-latitude'],
+          shakemap.properties['maximum-longitude']],
+          [shakemap.properties['minimum-latitude'],
+          shakemap.properties['minimum-longitude']]]">
       </shared-map>
     </a>
 

--- a/src/app/shakemap/intensity/intensity.component.spec.ts
+++ b/src/app/shakemap/intensity/intensity.component.spec.ts
@@ -24,7 +24,12 @@ describe('IntensityComponent', () => {
         IntensityComponent,
 
         MockComponent({
-          inputs: ['overlays', 'showScaleControl', 'showAttributionControl'],
+          inputs: [
+            'overlays',
+            'showScaleControl',
+            'showAttributionControl',
+            'bounds'
+          ],
           selector: 'shared-map'
         }),
 

--- a/src/app/shakemap/pga/pga.component.html
+++ b/src/app/shakemap/pga/pga.component.html
@@ -13,7 +13,6 @@
     <shared-map
         [overlays]="shakemap | shakemapOverlays:['shakemap-pga',
         'shakemap-stations']"
-        [baselayer]="'Grayscale'"
         [showScaleControl]="true"
         [showAttributionControl]="false"
         [bounds]="[[shakemap.properties['maximum-latitude'],

--- a/src/app/shakemap/pga/pga.component.html
+++ b/src/app/shakemap/pga/pga.component.html
@@ -12,10 +12,14 @@
 
     <shared-map
         [overlays]="shakemap | shakemapOverlays:['shakemap-pga',
-            'shakemap-stations']"
+        'shakemap-stations']"
         [baselayer]="'Grayscale'"
         [showScaleControl]="true"
-        [showAttributionControl]="false">
+        [showAttributionControl]="false"
+        [bounds]="[[shakemap.properties['maximum-latitude'],
+        shakemap.properties['maximum-longitude']],
+        [shakemap.properties['minimum-latitude'],
+        shakemap.properties['minimum-longitude']]]">
     </shared-map>
   </a>
 

--- a/src/app/shakemap/pga/pga.component.spec.ts
+++ b/src/app/shakemap/pga/pga.component.spec.ts
@@ -27,7 +27,7 @@ describe('PgaComponent', () => {
             'overlays',
             'showScaleControl',
             'showAttributionControl',
-            'baselayer'
+            'bounds'
           ],
           selector: 'shared-map'
         }),

--- a/src/app/shakemap/pgv/pgv.component.html
+++ b/src/app/shakemap/pgv/pgv.component.html
@@ -12,10 +12,14 @@
 
     <shared-map
         [overlays]="shakemap | shakemapOverlays:['shakemap-pgv',
-          'shakemap-stations']"
+        'shakemap-stations']"
         [baselayer]="'Grayscale'"
         [showScaleControl]="true"
-        [showAttributionControl]="false">
+        [showAttributionControl]="false"
+        [bounds]="[[shakemap.properties['maximum-latitude'],
+        shakemap.properties['maximum-longitude']],
+        [shakemap.properties['minimum-latitude'],
+        shakemap.properties['minimum-longitude']]]">
     </shared-map>
   </a>
 

--- a/src/app/shakemap/pgv/pgv.component.html
+++ b/src/app/shakemap/pgv/pgv.component.html
@@ -13,7 +13,6 @@
     <shared-map
         [overlays]="shakemap | shakemapOverlays:['shakemap-pgv',
         'shakemap-stations']"
-        [baselayer]="'Grayscale'"
         [showScaleControl]="true"
         [showAttributionControl]="false"
         [bounds]="[[shakemap.properties['maximum-latitude'],

--- a/src/app/shakemap/pgv/pgv.component.spec.ts
+++ b/src/app/shakemap/pgv/pgv.component.spec.ts
@@ -28,7 +28,7 @@ describe('PgvComponent', () => {
             'overlays',
             'showScaleControl',
             'showAttributionControl',
-            'baselayer'
+            'bounds'
           ],
           selector: 'shared-map'
         }),

--- a/src/app/shakemap/psa/psa.component.html
+++ b/src/app/shakemap/psa/psa.component.html
@@ -18,7 +18,6 @@
       <shared-map
           [overlays]="shakemap | shakemapOverlays:['shakemap-psa03',
           'shakemap-stations']"
-          [baselayer]="'Grayscale'"
           [showScaleControl]="true"
           [showAttributionControl]="false"
           [bounds]="[[shakemap.properties['maximum-latitude'],
@@ -56,7 +55,6 @@
       <shared-map
           [overlays]="shakemap | shakemapOverlays:['shakemap-psa10',
           'shakemap-stations']"
-          [baselayer]="'Grayscale'"
           [showScaleControl]="true"
           [showAttributionControl]="false"
           [bounds]="[[shakemap.properties['maximum-latitude'],
@@ -94,7 +92,6 @@
       <shared-map
           [overlays]="shakemap | shakemapOverlays:['shakemap-psa30',
           'shakemap-stations']"
-          [baselayer]="'Grayscale'"
           [showScaleControl]="true"
           [showAttributionControl]="false"
           [bounds]="[[shakemap.properties['maximum-latitude'],

--- a/src/app/shakemap/psa/psa.component.html
+++ b/src/app/shakemap/psa/psa.component.html
@@ -20,7 +20,11 @@
           'shakemap-stations']"
           [baselayer]="'Grayscale'"
           [showScaleControl]="true"
-          [showAttributionControl]="false">
+          [showAttributionControl]="false"
+          [bounds]="[[shakemap.properties['maximum-latitude'],
+          shakemap.properties['maximum-longitude']],
+          [shakemap.properties['minimum-latitude'],
+          shakemap.properties['minimum-longitude']]]">
       </shared-map>
     </a>
   </ng-container>
@@ -54,7 +58,11 @@
           'shakemap-stations']"
           [baselayer]="'Grayscale'"
           [showScaleControl]="true"
-          [showAttributionControl]="false">
+          [showAttributionControl]="false"
+          [bounds]="[[shakemap.properties['maximum-latitude'],
+          shakemap.properties['maximum-longitude']],
+          [shakemap.properties['minimum-latitude'],
+          shakemap.properties['minimum-longitude']]]">
       </shared-map>
     </a>
   </ng-container>
@@ -88,7 +96,11 @@
           'shakemap-stations']"
           [baselayer]="'Grayscale'"
           [showScaleControl]="true"
-          [showAttributionControl]="false">
+          [showAttributionControl]="false"
+          [bounds]="[[shakemap.properties['maximum-latitude'],
+          shakemap.properties['maximum-longitude']],
+          [shakemap.properties['minimum-latitude'],
+          shakemap.properties['minimum-longitude']]]">
       </shared-map>
     </a>
   </ng-container>

--- a/src/app/shakemap/psa/psa.component.spec.ts
+++ b/src/app/shakemap/psa/psa.component.spec.ts
@@ -28,7 +28,7 @@ describe('PsaComponent', () => {
             'overlays',
             'showScaleControl',
             'showAttributionControl',
-            'baselayer'
+            'bounds'
           ],
           selector: 'shared-map'
         }),

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.spec.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.spec.ts
@@ -98,32 +98,6 @@ describe('ShakemapContoursOverlay', () => {
     });
   });
 
-  describe('after add', () => {
-    beforeEach(() => {
-      overlay.map = {
-        fitBounds: function(bounds) {}
-      };
-    });
-
-    it('gets bounds', () => {
-      const bounds = 'BOUNDS';
-      spyOn(overlay, 'getBounds').and.returnValue(bounds);
-
-      overlay.afterAdd();
-      expect(overlay.bounds).toBe(bounds);
-    });
-
-    it('sets map bounds', () => {
-      const bounds = 'BOUNDS';
-      spyOn(overlay, 'getBounds').and.returnValue(bounds);
-
-      const mapSpy = spyOn(overlay.map, 'fitBounds').and.callFake(() => {});
-
-      overlay.afterAdd();
-      expect(mapSpy).toHaveBeenCalledWith(bounds);
-    });
-  });
-
   describe('getAngle', () => {
     it('calculates the correct angle', () => {
       const angle = overlay.getAngle([0, 0], [1, 1]);

--- a/src/app/shared/map-overlay/shakemap-contours-overlay.ts
+++ b/src/app/shared/map-overlay/shakemap-contours-overlay.ts
@@ -34,14 +34,6 @@ const ShakemapContoursOverlay = AsynchronousGeoJSONOverlay.extend({
   },
 
   /**
-   * Adds map bounds to overlay
-   */
-  afterAdd: function() {
-    this.bounds = this.getBounds();
-    this.map.fitBounds(this.bounds);
-  },
-
-  /**
    * Generates label content that will be displayed inline with the contour
    *
    * @param feature

--- a/src/app/shared/map/map.component.ts
+++ b/src/app/shared/map/map.component.ts
@@ -147,7 +147,8 @@ export class MapComponent implements AfterViewInit {
       scrollWheelZoom: false,
       tap: true,
       touchZoom: true,
-      zoomControl: false
+      zoomControl: false,
+      zoomSnap: 0
     });
 
     this.layersControl = L.control.layers(baselayers, {});


### PR DESCRIPTION
closes #1128 

Use max/min lat/lon from Shakemap product to set map bounds
Switched to default basemap for all static maps
Set zoomSnap to 0 to allow precise setting of bounds