### PR TITLE
changed opacity on finite fault map overlay to 0.5, and stroke width to 0.4

### DIFF
--- a/src/app/shared/map-overlay/finite-fault-map-overlay.ts
+++ b/src/app/shared/map-overlay/finite-fault-map-overlay.ts
@@ -49,8 +49,8 @@ const FiniteFaultMapOverlay = AsynchronousGeoJSONOverlay.extend({
       layer.setStyle({
         color: '#666',
         fillColor: feature.properties.fill,
-        fillOpacity: feature.properties['fill-opacity'],
-        weight: feature.properties['stroke-width']
+        fillOpacity: 0.5,
+        weight: 0.4
       });
       layer.bindPopup(this.formatPopup(feature));
     }


### PR DESCRIPTION
Fixes #1365 