### PR TITLE
Change expiration rules

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,11 +44,11 @@ cat <<-EO_CONFIG> ${NGINX_CONF_DIR}/00-server.conf
 # most files expire soon
 expires 5m;
 # images are not hash-stamped, but change infrequently
-location ~* (?:jpg|png|svg) {
+location ~* \\.(?:jpg|png|svg)\$ {
   expires 1d;
 }
 # css/js are hash-stamped, and url will change if content changes
-location ~* (?:css|js) {
+location ~* \\.(?:css|js)\$ {
   expires 1y;
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,12 +40,23 @@ done
 
 # Write configuration file for NGINX
 cat <<-EO_CONFIG> ${NGINX_CONF_DIR}/00-server.conf
+
+# most files expire soon
+expires 5m;
+# images are not hash-stamped, but change infrequently
+location ~* (?:jpg|png|svg) {
+  expires 1d;
+}
+# css/js are hash-stamped, and url will change if content changes
+location ~* (?:css|js) {
+  expires 1y;
+}
+
 location  /${BASE_HREF}  {
   add_header  'X-Frame-Options'  'DENY';
   add_header  'X-Content-Type-Options'  'nosniff';
   add_header  'X-XSS-Protection'  '1; mode=block';
 
-  expires 15m;
   add_header 'Cache-Control' 'public';
 
   try_files \$uri \$uri/ \$uri.html \$uri/index.html @angular-fallback;


### PR DESCRIPTION
Only affects urls served from this container.

- 5 minutes by default

This is the html page, which may reference new js/css files after a deploy; expire quickly.

- 1 day for images (jpg, png, svg)

These are assets, which may be updated but change less frequently; expire regularly

- 1 year for js/css

These are hash-stamped versions of files, and new filenames are created with every deploy; expire never.
