### PR TITLE
Column spacing on mat-tables

### DIFF
--- a/src/app/origin/magnitude-detail/magnitude-detail.component.scss
+++ b/src/app/origin/magnitude-detail/magnitude-detail.component.scss
@@ -1,3 +1,8 @@
 .mag-detail-table.mat-table {
   min-width: 800px;
 }
+
+.mat-column-channel,
+.mat-column-amplitude {
+  flex: 2;
+}

--- a/src/app/origin/phase/phase.component.scss
+++ b/src/app/origin/phase/phase.component.scss
@@ -1,3 +1,7 @@
 .phase-table.mat-table {
   min-width: 950px;
 }
+
+.mat-column-channel {
+  flex: 2;
+}

--- a/src/app/pager/pager/pager.component.scss
+++ b/src/app/pager/pager/pager.component.scss
@@ -15,7 +15,7 @@
     }
 
     .mat-column-population {
-      flex-basis: 100px;
+      flex: 0.5;
     }
   }
 

--- a/src/app/shared/css/description-table.scss
+++ b/src/app/shared/css/description-table.scss
@@ -14,8 +14,8 @@
  */
 
 dl.description-table {
-  font-family: Roboto, "Helvetica Neue Light", "Helvetica Neue", Helvetica,
-    Arial, "Lucida Grande", sans-serif;
+  font-family: Roboto, 'Helvetica Neue Light', 'Helvetica Neue', Helvetica,
+    Arial, 'Lucida Grande', sans-serif;
 
   /* default size/color based on mat-header-cell */
   > dt {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,14 +1,14 @@
 /* You can add global styles to this file, and also import other style files */
 
-@import "./app/shared/css/contour-overlay.scss";
-@import "./app/shared/css/description-table.scss";
-@import "./app/shared/css/horizontal-scrolling.scss";
-@import "./app/shared/css/mmi-colors.scss";
-@import "./app/shared/css/station-overlay.scss";
+@import './app/shared/css/contour-overlay.scss';
+@import './app/shared/css/description-table.scss';
+@import './app/shared/css/horizontal-scrolling.scss';
+@import './app/shared/css/mmi-colors.scss';
+@import './app/shared/css/station-overlay.scss';
 
 /* Leaflet Styles */
-@import "./app/shared/css/leaflet-styles.scss"; // import before legend-control.scss
-@import "./app/shared/map-control/legend-control.scss";
+@import './app/shared/css/leaflet-styles.scss'; // import before legend-control.scss
+@import './app/shared/map-control/legend-control.scss';
 
 header > h1 {
   margin-bottom: 0;
@@ -43,7 +43,7 @@ mdc-tab-bar-scroller.mdc-tab-bar-scroller {
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }
 
-@import "~@angular-mdc/theme/material";
+@import '~@angular-mdc/theme/material';
 
 /* allow wrapping on small screens */
 .mat-radio-label-content {
@@ -58,4 +58,10 @@ img {
 
 .sidenav-content {
   overflow: hidden;
+}
+
+mat-cell,
+mat-footer-cell,
+mat-header-cell {
+  padding: 0 1em;
 }


### PR DESCRIPTION
fixes #1244 

Add space so that column values do not smush together, and stop values from wrapping onto multiple lines