### PR TITLE
Return N/A from sharedRoman

### DIFF
--- a/src/app/executive/shakemap-pin/shakemap-pin.component.html
+++ b/src/app/executive/shakemap-pin/shakemap-pin.component.html
@@ -5,8 +5,7 @@
     <a [routerLink]="link">{{ title }}</a>
     <shared-mmi
         [bubble]="true"
-        [intensity]="product | sharedProductProperty:'maxmmi' |
-            sharedNumber:0:0">
+        [intensity]="product | sharedProductProperty:'maxmmi'">
     </shared-mmi>
   </div>
 

--- a/src/app/shared/mmi/mmi.component.scss
+++ b/src/app/shared/mmi/mmi.component.scss
@@ -7,6 +7,7 @@
   display: inline-block;
   padding: 0.5em;
   text-align: center;
+  background-color: #eee;
 
   > span {
     color: #000;

--- a/src/app/shared/roman.pipe.spec.ts
+++ b/src/app/shared/roman.pipe.spec.ts
@@ -1,14 +1,18 @@
 import { RomanPipe } from './roman.pipe';
 
 describe('RomanPipe', () => {
+  let pipe;
+
+  beforeEach(() => {
+    pipe = new RomanPipe();
+  });
+
   it('create an instance', () => {
-    const pipe = new RomanPipe();
     expect(pipe).toBeTruthy();
   });
 
   describe('transform', () => {
     it('returns the roman numeral corresponding to the value', () => {
-      const pipe = new RomanPipe();
 
       expect(pipe.transform(0)).toEqual('I');
       expect(pipe.transform(1)).toEqual('I');
@@ -25,11 +29,17 @@ describe('RomanPipe', () => {
       expect(pipe.transform(11.49)).toEqual('XI');
       expect(pipe.transform(11.5)).toEqual('XII');
       expect(pipe.transform(12)).toEqual('XII');
+    });
 
+    it('returns "N/A" for non-mmi inputs', () => {
       expect(pipe.transform(-1)).toBe('N/A');
       expect(pipe.transform(13)).toBe('N/A');
       expect(pipe.transform(null)).toBe('N/A');
       expect(pipe.transform('--')).toBe('N/A');
+    });
+
+    it('returns custom N/A value for non-mmi inputs', () => {
+      expect(pipe.transform('--', 'CUSTOM')).toBe('CUSTOM');
     });
   });
 });

--- a/src/app/shared/roman.pipe.spec.ts
+++ b/src/app/shared/roman.pipe.spec.ts
@@ -26,8 +26,10 @@ describe('RomanPipe', () => {
       expect(pipe.transform(11.5)).toEqual('XII');
       expect(pipe.transform(12)).toEqual('XII');
 
-      expect(pipe.transform(-1)).toBeNull();
-      expect(pipe.transform(13)).toBeNull();
+      expect(pipe.transform(-1)).toBe('N/A');
+      expect(pipe.transform(13)).toBe('N/A');
+      expect(pipe.transform(null)).toBe('N/A');
+      expect(pipe.transform('--')).toBe('N/A');
     });
   });
 });

--- a/src/app/shared/roman.pipe.ts
+++ b/src/app/shared/roman.pipe.ts
@@ -20,8 +20,6 @@ export class RomanPipe implements PipeTransform {
     'XII'
   ];
 
-  static NO_MMI = 'N/A';
-
   /**
    * Get roman numeral from a number
    *
@@ -31,7 +29,7 @@ export class RomanPipe implements PipeTransform {
    * @return {any}
    *     A roman numeral
    */
-  transform(mmi: any): string {
+  transform(mmi: any, noMmi = 'N/A'): string {
     let value;
 
     mmi = Math.round(parseFloat(mmi));
@@ -41,6 +39,6 @@ export class RomanPipe implements PipeTransform {
       return value;
     }
 
-    return RomanPipe.NO_MMI;
+    return noMmi;
   }
 }

--- a/src/app/shared/roman.pipe.ts
+++ b/src/app/shared/roman.pipe.ts
@@ -20,6 +20,8 @@ export class RomanPipe implements PipeTransform {
     'XII'
   ];
 
+  static NO_MMI = 'N/A';
+
   /**
    * Get roman numeral from a number
    *
@@ -39,6 +41,6 @@ export class RomanPipe implements PipeTransform {
       return value;
     }
 
-    return null;
+    return RomanPipe.NO_MMI;
   }
 }

--- a/src/app/shared/roman.pipe.ts
+++ b/src/app/shared/roman.pipe.ts
@@ -31,10 +31,10 @@ export class RomanPipe implements PipeTransform {
    * @return {any}
    *     A roman numeral
    */
-  transform(mmi: number): any {
+  transform(mmi: any): string {
     let value;
 
-    mmi = Math.round(mmi);
+    mmi = Math.round(parseFloat(mmi));
     value = RomanPipe.MMI_ROMAN[mmi];
 
     if (value) {


### PR DESCRIPTION
closes #1467 

If the value passed into the pipe is not a number or present in the roman numeral lookup, return 'N/A'