### PR TITLE
Add styles for no-mmi stations in station-overlay

### DIFF
--- a/src/app/shared/css/station-overlay.scss
+++ b/src/app/shared/css/station-overlay.scss
@@ -81,6 +81,16 @@
   border-bottom-color: $mmiXII !important;
 }
 
+.station-overlay-station-layer-icon.station-mmiN\/A {
+  &:before {
+    border-bottom-color: transparent
+  }
+
+  &:after {
+    border-bottom-color: rgba(0, 0, 0, .2);
+  }
+}
+
 .leaflet-popup shakemap-station {
   dl.description-table {
     /* 24px column gaps */


### PR DESCRIPTION
closes #1504 

Makes stations transparent/gray when they're missing an MMI