### PR TITLE
Map overflow bug

### DIFF
--- a/src/app/shakemap/shakemap/shakemap.component.scss
+++ b/src/app/shakemap/shakemap/shakemap.component.scss
@@ -1,5 +1,5 @@
 .shakemap-map {
-  width: 600px;
+  max-width: 600px;
 }
 
 shared-map {


### PR DESCRIPTION
fixes #1578

Set static width to max width in order to avoid shakemap overflow on mobile