### PR TITLE
Switching between versions in summary component

### DIFF
--- a/src/app/shared/dyfi-summary/dyfi-summary.component.html
+++ b/src/app/shared/dyfi-summary/dyfi-summary.component.html
@@ -5,7 +5,9 @@
       *matRowDef="let product; columns: this.columnsToDisplay"
       class="link"
       [class.selected]="product === event.product"
-      [routerLink]="['/', event?.id, 'dyfi']"
+      [routerLink]="
+        router.url.indexOf('dyfi') === -1 ? ['/', event?.id, 'dyfi'] : null
+      "
       [queryParams]="{ source: product?.source, code: product?.code }"
     ></mat-row>
 
@@ -17,7 +19,9 @@
           </shared-preferred-check>
         </ng-container>
         <a
-          [routerLink]="['/', event?.id, 'dyfi']"
+          [routerLink]="
+            router.url.indexOf('dyfi') === -1 ? ['/', event?.id, 'dyfi'] : null
+          "
           [queryParams]="{ source: product?.source, code: product?.code }"
         >
           {{ dyfi?.properties?.eventsource | uppercase }}

--- a/src/app/shared/dyfi-summary/dyfi-summary.component.spec.ts
+++ b/src/app/shared/dyfi-summary/dyfi-summary.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTableModule } from '@angular/material';
 import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { MockComponent } from 'ng2-mock-component';
 
@@ -27,7 +28,7 @@ describe('DyfisummaryComponent', () => {
           selector: 'shared-preferred-check'
         })
       ],
-      imports: [MatTableModule, RouterModule]
+      imports: [MatTableModule, RouterModule, RouterTestingModule]
     }).compileComponents();
   }));
 

--- a/src/app/shared/dyfi-summary/dyfi-summary.component.ts
+++ b/src/app/shared/dyfi-summary/dyfi-summary.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { Event } from '../../event';
-
 
 /**
  * renders dyfi summary table
@@ -26,4 +26,11 @@ export class DyfiSummaryComponent {
 
   @Input()
   products: Array<any> = [];
+
+  // router information
+  router: Router;
+
+  constructor(router: Router) {
+    this.router = router;
+  }
 }

--- a/src/app/shared/finite-fault-summary/finite-fault-summary.component.html
+++ b/src/app/shared/finite-fault-summary/finite-fault-summary.component.html
@@ -4,7 +4,11 @@
     *matRowDef="let product; columns: this.columnsToDisplay"
     class="link"
     [class.selected]="product === event.product"
-    [routerLink]="['/', event?.id, 'finite-fault']"
+    [routerLink]="
+      router.url.indexOf('finite-fault') === -1
+        ? ['/', event?.id, 'finite-fault']
+        : null
+    "
     [queryParams]="{ source: product?.source, code: product?.code }"
   >
   </mat-row>
@@ -17,7 +21,11 @@
         </shared-preferred-check>
       </ng-container>
       <a
-        [routerLink]="['/', event?.id, 'finite-fault']"
+        [routerLink]="
+          router.url.indexOf('finite-fault') === -1
+            ? ['/', event?.id, 'finite-fault']
+            : null
+        "
         [queryParams]="{ source: product?.source, code: product?.code }"
       >
         {{ product | sharedProductProperty: 'eventsource' | uppercase }}

--- a/src/app/shared/finite-fault-summary/finite-fault-summary.component.ts
+++ b/src/app/shared/finite-fault-summary/finite-fault-summary.component.ts
@@ -1,8 +1,5 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -12,18 +9,18 @@ import {
 })
 export class FiniteFaultSummaryComponent {
   // Table headers
-  columnsToDisplay = [
-    'catalog',
-    'derived-magnitude',
-    'maximum-slip',
-    'source'
-  ];
+  columnsToDisplay = ['catalog', 'derived-magnitude', 'maximum-slip', 'source'];
 
   @Input()
   event: any;
+
   @Input()
   products: Array<any>;
 
-  constructor() { }
+  // router information
+  router: Router;
 
+  constructor(router: Router) {
+    this.router = router;
+  }
 }

--- a/src/app/shared/focal-mechanism-summary/focal-mechanism-summary.component.html
+++ b/src/app/shared/focal-mechanism-summary/focal-mechanism-summary.component.html
@@ -5,7 +5,11 @@
       *matRowDef="let tensor; columns: this.columnsToDisplay"
       class="link"
       [class.selected]="tensor.product === event.product"
-      [routerLink]="['/', event?.id, 'focal-mechanism']"
+      [routerLink]="
+        router.url.indexOf('focal-mechanism') === -1
+          ? ['/', event?.id, 'focal-mechanism']
+          : null
+      "
       [queryParams]="{
         source: tensor?.product?.source,
         code: tensor?.product?.code
@@ -21,7 +25,11 @@
           </shared-preferred-check>
         </ng-container>
         <a
-          [routerLink]="['/', event?.id, 'focal-mechanism']"
+          [routerLink]="
+            router.url.indexOf('focal-mechanism') === -1
+              ? ['/', event?.id, 'focal-mechanism']
+              : null
+          "
           [queryParams]="{
             source: tensor?.product?.source,
             code: tensor?.product?.code

--- a/src/app/shared/focal-mechanism-summary/focal-mechanism-summary.component.spec.ts
+++ b/src/app/shared/focal-mechanism-summary/focal-mechanism-summary.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTableModule, MatIconModule } from '@angular/material';
 import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { MockComponent } from 'ng2-mock-component';
 import { MockPipe } from '../../mock-pipe';
@@ -36,7 +37,12 @@ describe('FocalMechanismSummaryComponent', () => {
         MockPipe('sharedDegrees'),
         MockPipe('sharedProductProperty')
       ],
-      imports: [MatIconModule, MatTableModule, RouterModule],
+      imports: [
+        MatIconModule,
+        MatTableModule,
+        RouterModule,
+        RouterTestingModule
+      ],
       providers: []
     }).compileComponents();
   }));

--- a/src/app/shared/focal-mechanism-summary/focal-mechanism-summary.component.ts
+++ b/src/app/shared/focal-mechanism-summary/focal-mechanism-summary.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { Tensor } from '@shared/beachball/tensor';
-
 
 /**
  * Focal mechanism component, renders a table with data
@@ -28,8 +28,14 @@ export class FocalMechanismSummaryComponent {
   @Input()
   event: any;
 
+  // router information
+  router: Router;
+
   tensors: Array<any> = [];
 
+  constructor(router: Router) {
+    this.router = router;
+  }
   /**
    * Setter to set the products array
    * @param products

--- a/src/app/shared/origin-summary/origin-summary.component.html
+++ b/src/app/shared/origin-summary/origin-summary.component.html
@@ -6,7 +6,9 @@
       *matRowDef="let product; columns: this.columnsToDisplay"
       class="link"
       [class.selected]="product === event.product"
-      [routerLink]="['/', event?.id, 'origin']"
+      [routerLink]="
+        router.url.indexOf('origin') === -1 ? ['/', event?.id, 'origin'] : null
+      "
       [queryParams]="{ source: product?.source, code: product?.code }"
     >
     </mat-row>
@@ -19,7 +21,11 @@
           </shared-preferred-check>
         </ng-container>
         <a
-          [routerLink]="['/', event?.id, 'origin']"
+          [routerLink]="
+            router.url.indexOf('origin') === -1
+              ? ['/', event?.id, 'origin']
+              : null
+          "
           [queryParams]="{ source: product?.source, code: product?.code }"
         >
           {{ product?.properties?.eventsource?.toUpperCase() }}

--- a/src/app/shared/origin-summary/origin-summary.component.ts
+++ b/src/app/shared/origin-summary/origin-summary.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { FormatterService } from '@core/formatter.service';
-
 
 /**
  * Technical origin component
@@ -30,10 +30,16 @@ export class OriginSummaryComponent {
 
   @Input()
   event: any;
+
   @Input()
   products: Array<any>;
 
-  constructor(public formatterService: FormatterService) {}
+  // router information
+  router: Router;
+
+  constructor(public formatterService: FormatterService, router: Router) {
+    this.router = router;
+  }
 
   /**
    * Returns a date object from a string

--- a/src/app/shared/pager-summary/pager-summary.component.html
+++ b/src/app/shared/pager-summary/pager-summary.component.html
@@ -5,7 +5,9 @@
       *matRowDef="let product; columns: this.columnsToDisplay"
       class="link"
       [class.selected]="product === event.product"
-      [routerLink]="['/', event?.id, 'pager']"
+      [routerLink]="
+        router.url.indexOf('pager') === -1 ? ['/', event?.id, 'pager'] : null
+      "
       [queryParams]="{ source: product?.source, code: product?.code }"
     ></mat-row>
 
@@ -17,7 +19,11 @@
           </shared-preferred-check>
         </ng-container>
         <a
-          [routerLink]="['/', event?.id, 'pager']"
+          [routerLink]="
+            router.url.indexOf('pager') === -1
+              ? ['/', event?.id, 'pager']
+              : null
+          "
           [queryParams]="{ source: product?.source, code: product?.code }"
         >
           {{ pager?.properties?.eventsource?.toUpperCase() }}

--- a/src/app/shared/pager-summary/pager-summary.component.spec.ts
+++ b/src/app/shared/pager-summary/pager-summary.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTableModule } from '@angular/material';
 import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { MockComponent } from 'ng2-mock-component';
 
@@ -27,7 +28,7 @@ describe('PagerSummaryComponent', () => {
           selector: 'shared-preferred-check'
         })
       ],
-      imports: [MatTableModule, RouterModule]
+      imports: [MatTableModule, RouterModule, RouterTestingModule]
     }).compileComponents();
   }));
 

--- a/src/app/shared/pager-summary/pager-summary.component.ts
+++ b/src/app/shared/pager-summary/pager-summary.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { Event } from '../../event';
 
@@ -25,4 +26,11 @@ export class PagerSummaryComponent {
 
   @Input()
   products: Array<any> = [];
+
+  // router information
+  router: Router;
+
+  constructor(router: Router) {
+    this.router = router;
+  }
 }

--- a/src/app/shared/shakemap-summary/shakemap-summary.component.html
+++ b/src/app/shared/shakemap-summary/shakemap-summary.component.html
@@ -5,7 +5,11 @@
       *matRowDef="let product; columns: this.columnsToDisplay"
       class="link"
       [class.selected]="product === event.product"
-      [routerLink]="['/', event?.id, 'shakemap']"
+      [routerLink]="
+        router.url.indexOf('shakemap') === -1
+          ? ['/', event?.id, 'shakemap']
+          : null
+      "
       [queryParams]="{ source: product?.source, code: product?.code }"
     ></mat-row>
 
@@ -17,7 +21,11 @@
           </shared-preferred-check>
         </ng-container>
         <a
-          [routerLink]="['/', event?.id, 'shakemap']"
+          [routerLink]="
+            router.url.indexOf('shakemap') === -1
+              ? ['/', event?.id, 'shakemap']
+              : null
+          "
           [queryParams]="{ source: product?.source, code: product?.code }"
         >
           {{ shakemap?.properties?.eventsource?.toUpperCase() }}

--- a/src/app/shared/shakemap-summary/shakemap-summary.component.spec.ts
+++ b/src/app/shared/shakemap-summary/shakemap-summary.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTableModule } from '@angular/material';
 import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { MockComponent } from 'ng2-mock-component';
 
@@ -27,7 +28,7 @@ describe('ShakeMapSummaryComponent', () => {
           selector: 'shared-preferred-check'
         })
       ],
-      imports: [MatTableModule, RouterModule]
+      imports: [MatTableModule, RouterModule, RouterTestingModule]
     }).compileComponents();
   }));
 

--- a/src/app/shared/shakemap-summary/shakemap-summary.component.ts
+++ b/src/app/shared/shakemap-summary/shakemap-summary.component.ts
@@ -1,7 +1,7 @@
-import { ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { Event } from '../../event';
-
 
 /**
  * Renders shakemap summary table
@@ -26,4 +26,11 @@ export class ShakemapSummaryComponent {
 
   @Input()
   products: Array<any> = [];
+
+  // router information
+  router: Router;
+
+  constructor(router: Router) {
+    this.router = router;
+  }
 }


### PR DESCRIPTION
fixes #1593 

Ensure that the summary components link to the correct pages from the impact/technical summary pages, and that tab position is maintained when switching between contributed versions on the product page