### PR TITLE
Display LocationError in SnackBar

### DIFF
--- a/src/app/shared/geo.service.ts
+++ b/src/app/shared/geo.service.ts
@@ -103,7 +103,7 @@ export class GeoService {
         if (response.locations && response.locations.length !== 0) {
           this.onGeocodeSuccess(response.locations[0]);
         } else {
-          this.onGeocodeError(null); // TODO
+          this.onGeocodeError(response);
         }
       });
 
@@ -171,8 +171,17 @@ export class GeoService {
     return of(noLocation);
   }
 
-  private onGeocodeError(error: any): void {
-    console.log('TODO :: onGeocodeError', error);
+  private onGeocodeError(response: any): void {
+    let message = 'Geocoding failed';
+
+    if (response && response.locations && response.locations.length === 0) {
+      message = 'No location found';
+    }
+    this.error.next({
+      code: -1,
+      message: message
+    } as LocationError);
+
     setTimeout(_ => this.geocoding.next(false), this.flickerTimeout);
   }
 

--- a/src/app/tell-us/form/location/location.component.spec.ts
+++ b/src/app/tell-us/form/location/location.component.spec.ts
@@ -3,9 +3,10 @@ import { MatSnackBar } from '@angular/material';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { MockComponent } from 'ng2-mock-component';
+import { of } from 'rxjs/observable/of';
 
 import { LocationComponent } from './location.component';
-import { GeoService } from '@shared/geo.service';
+import { GeoService, LocationError } from '@shared/geo.service';
 import { MockPipe } from 'app/mock-pipe';
 import { FormatterService } from '@core/formatter.service';
 
@@ -20,6 +21,12 @@ describe('LocationComponent', () => {
     };
     const snackBarStub = {
       open: jasmine.createSpy('snackBar::open')
+    };
+    const geoServiceStub = {
+      error$: of({
+        code: -1,
+        message: 'test'
+      } as LocationError)
     };
 
     TestBed.configureTestingModule({
@@ -60,7 +67,8 @@ describe('LocationComponent', () => {
       providers: [
         GeoService,
         { provide: MatSnackBar, useValue: snackBarStub },
-        { provide: FormatterService, useValue: formatterServiceStub }
+        { provide: FormatterService, useValue: formatterServiceStub },
+        { provide: GeoService, useValue: geoServiceStub }
       ]
     }).compileComponents();
 
@@ -84,6 +92,23 @@ describe('LocationComponent', () => {
       expect(component.snackBar.open).toHaveBeenCalledWith(message, action, {
         duration: length
       });
+    });
+  });
+
+  describe('ngOnInit', () => {
+    it('sets up subscription that calls openSnackBar', () => {
+      spyOn(component, 'openSnackBar');
+      component.ngOnInit();
+      expect(component.openSnackBar).toHaveBeenCalled();
+      expect(component.openSnackBar).toHaveBeenCalledWith('test', 'close');
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('removes subscription to geoservice', () => {
+      spyOn(component.subscription, 'unsubscribe');
+      component.ngOnDestroy();
+      expect(component.subscription.unsubscribe).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/tell-us/form/location/location.component.ts
+++ b/src/app/tell-us/form/location/location.component.ts
@@ -1,18 +1,42 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MatSnackBar } from '@angular/material';
 
-import { GeoService } from '@shared/geo.service';
+import { GeoService, LocationError } from '@shared/geo.service';
 
 import { AbstractForm } from '../abstract-form.component';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'tell-us-form-location',
   styleUrls: ['./location.component.scss'],
   templateUrl: './location.component.html'
 })
-export class LocationComponent extends AbstractForm {
+export class LocationComponent extends AbstractForm
+  implements OnInit, OnDestroy {
+  subscription = new Subscription();
+
   constructor(public geoService: GeoService, public snackBar: MatSnackBar) {
     super();
+  }
+
+  /**
+   * Unsubscribe from the GeoService.error$ observable
+   */
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  /**
+   * Subscribe to GeoService.error$ and display error in a SnackBar component
+   */
+  ngOnInit() {
+    this.subscription = this.geoService.error$.subscribe(
+      (locationError: LocationError) => {
+        if (locationError) {
+          this.openSnackBar(locationError.message, 'close');
+        }
+      }
+    );
   }
 
   /**
@@ -26,7 +50,7 @@ export class LocationComponent extends AbstractForm {
    *      amount of time to display the snackbar
    *
    */
-  openSnackBar(message: string, action: string, length: number) {
+  openSnackBar(message: string, action: string = null, length: number = 3000) {
     this.snackBar.open(message, action, {
       duration: length
     });


### PR DESCRIPTION
I decided to subscribe to the service in the `location.component` because that is where the user triggers a geocode or geolocate. If we were to have the `geo.service` show the MatSnackBar then it would have to be referenced in multiple places. It felt much easier to have the MatSnackBar accept a `LocationError` object and display the `LocationError.message` in the MatSnackBar.  