### PR TITLE
change map bounds from 4 degrees to 2 degrees

### DIFF
--- a/src/app/tell-us/form/location/map/map.component.scss
+++ b/src/app/tell-us/form/location/map/map.component.scss
@@ -17,6 +17,7 @@ shared-map {
 @media screen and (min-width: 1286px) {
   :host {
     display: block;
+    padding-bottom: 0;
     width: 960px;
     height: 960px;
   }

--- a/src/app/tell-us/form/location/map/map.component.spec.ts
+++ b/src/app/tell-us/form/location/map/map.component.spec.ts
@@ -117,7 +117,7 @@ describe('MapComponent', () => {
 
   describe('updatePin', () => {
     it('sets the map pin and map bounds', () => {
-      const latLng = [2, 2];
+      const latLng = [1, 1];
 
       spyOn(component, 'getLatLng').and.callFake(() => {
         return latLng;
@@ -129,7 +129,7 @@ describe('MapComponent', () => {
       expect(component.getLatLng).toHaveBeenCalled();
       expect(component.pin.setLatLng).toHaveBeenCalled();
       expect(component.pin.setLatLng).toHaveBeenCalledWith(latLng);
-      expect(component.mapBounds).toEqual([[4, 4], [0, 0]]);
+      expect(component.mapBounds).toEqual([[2, 2], [0, 0]]);
     });
   });
 });

--- a/src/app/tell-us/form/location/map/map.component.ts
+++ b/src/app/tell-us/form/location/map/map.component.ts
@@ -163,7 +163,7 @@ export class MapComponent extends AbstractForm
 
     const latitude = latLng[0];
     const longitude = latLng[1];
-    const radius = 2.0; // degrees
+    const radius = 1.0; // degrees
 
     if (latitude === 0 && longitude === 0) {
       this.mapBounds = WORLD_BOUNDS;


### PR DESCRIPTION
closes #1694 

This also includes a small style change to remove the bottom-padding from the map on larger screens. Without this style the map overflows its 960x960 px parent container