### PR TITLE
Add simple scroll link from form errors to the top of the page

### DIFF
--- a/src/app/tell-us/form/submit/submit.component.html
+++ b/src/app/tell-us/form/submit/submit.component.html
@@ -8,6 +8,11 @@
       {{ labels[error] ? labels[error] : error }}
     </li>
   </ul>
+  <p>
+    <a (click)="scrollToTop()" class="jump-link"
+      >Scroll to the top of the DYFI form</a
+    >
+  </p>
 </div>
 
 <form (ngSubmit)="onSubmit()">

--- a/src/app/tell-us/form/submit/submit.component.scss
+++ b/src/app/tell-us/form/submit/submit.component.scss
@@ -1,0 +1,4 @@
+.jump-link {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/src/app/tell-us/form/submit/submit.component.spec.ts
+++ b/src/app/tell-us/form/submit/submit.component.spec.ts
@@ -4,6 +4,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SubmitComponent } from './submit.component';
 import { FormSubmitService } from 'app/tell-us/form-submit.service';
 import { FeltReport } from 'app/tell-us/felt-report';
+import { WindowRef } from '@shared/window-ref-wrapper';
 
 describe('SubmitComponent', () => {
   let component: SubmitComponent;
@@ -17,6 +18,7 @@ describe('SubmitComponent', () => {
       declarations: [SubmitComponent],
       imports: [FormsModule],
       providers: [
+        WindowRef,
         { provide: FormSubmitService, useValue: formSubmitServiceStub }
       ]
     }).compileComponents();
@@ -47,9 +49,13 @@ describe('SubmitComponent', () => {
 
   describe('scrollToTop', () => {
     it('should call window.scroll', () => {
-      spyOn(window, 'scroll');
+      spyOn(component.windowRef.nativeWindow, 'scrollTo');
       component.scrollToTop();
-      expect(window.scroll).toHaveBeenCalled();
+      expect(component.windowRef.nativeWindow.scrollTo).toHaveBeenCalled();
+      expect(component.windowRef.nativeWindow.scrollTo).toHaveBeenCalledWith(
+        0,
+        0
+      );
     });
   });
 });

--- a/src/app/tell-us/form/submit/submit.component.spec.ts
+++ b/src/app/tell-us/form/submit/submit.component.spec.ts
@@ -44,4 +44,12 @@ describe('SubmitComponent', () => {
       );
     });
   });
+
+  describe('scrollToTop', () => {
+    it('should call window.scroll', () => {
+      spyOn(window, 'scroll');
+      component.scrollToTop();
+      expect(window.scroll).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/tell-us/form/submit/submit.component.ts
+++ b/src/app/tell-us/form/submit/submit.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 import { AbstractForm } from '../abstract-form.component';
 import { FormSubmitService } from 'app/tell-us/form-submit.service';
+import { WindowRef } from '@shared/window-ref-wrapper';
 
 @Component({
   selector: 'tell-us-form-submit',
@@ -9,7 +10,10 @@ import { FormSubmitService } from 'app/tell-us/form-submit.service';
   templateUrl: './submit.component.html'
 })
 export class SubmitComponent extends AbstractForm {
-  constructor(public formSubmitService: FormSubmitService) {
+  constructor(
+    public formSubmitService: FormSubmitService,
+    public windowRef: WindowRef
+  ) {
     super();
   }
 
@@ -17,6 +21,6 @@ export class SubmitComponent extends AbstractForm {
     this.formSubmitService.onSubmit(this.feltReport);
   }
   scrollToTop() {
-    window.scroll(0, 0);
+    this.windowRef.nativeWindow.scrollTo(0, 0);
   }
 }

--- a/src/app/tell-us/form/submit/submit.component.ts
+++ b/src/app/tell-us/form/submit/submit.component.ts
@@ -16,4 +16,7 @@ export class SubmitComponent extends AbstractForm {
   onSubmit() {
     this.formSubmitService.onSubmit(this.feltReport);
   }
+  scrollToTop() {
+    window.scroll(0, 0);
+  }
 }


### PR DESCRIPTION
fixes #1695 

This feels like a very simple solution. I started to go down the route of linking to the form inputs, however this would require refactoring the form. I am not sure if you can create an `ElementRef` unless the element is in the same component, so I believe we would have to flatten the structure of the form to provide focus to the actual form input when clicking on the link. 
