### PR TITLE
Add tooltips to shake-alert-overlay

### DIFF
--- a/src/app/shake-alert/shake-alert-confirmed/shake-alert-confirmed.component.html
+++ b/src/app/shake-alert/shake-alert-confirmed/shake-alert-confirmed.component.html
@@ -4,7 +4,7 @@
   event.
 </p>
 
-<div class="row">
+<div class="shake-alert row">
   <div class="column">
     <h4>Earthquake</h4>
     <dl *ngIf="properties" class="shake-alert-summary">

--- a/src/app/shake-alert/shake-alert-confirmed/shake-alert-confirmed.component.scss
+++ b/src/app/shake-alert/shake-alert-confirmed/shake-alert-confirmed.component.scss
@@ -8,7 +8,7 @@
   }
 }
 
-.time-label {
+.permanent-label {
   padding-top: 0;
   padding-bottom: 0;
 }

--- a/src/app/shake-alert/shake-alert-confirmed/shake-alert-confirmed.component.scss
+++ b/src/app/shake-alert/shake-alert-confirmed/shake-alert-confirmed.component.scss
@@ -8,18 +8,19 @@
   }
 }
 
-.column {
-  max-width: 500px;
+.time-label {
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 @media screen and (min-width: 500px) {
-  .row {
+  .shake-alert.row {
     display: flex;
     align-content: flex-start;
-  }
 
-  .column {
-    flex: 1;
-    min-width: 320px;
+    > .column {
+      flex: 1;
+      min-width: 320px;
+    }
   }
 }

--- a/src/app/shake-alert/shake-alert-confirmed/shake-alert-confirmed.component.ts
+++ b/src/app/shake-alert/shake-alert-confirmed/shake-alert-confirmed.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewEncapsulation } from '@angular/core';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
   selector: 'shake-alert-confirmed',
   styleUrls: ['./shake-alert-confirmed.component.scss'],
   templateUrl: './shake-alert-confirmed.component.html'

--- a/src/app/shared/date-time.pipe.spec.ts
+++ b/src/app/shared/date-time.pipe.spec.ts
@@ -1,7 +1,7 @@
 import { DateTimePipe } from './date-time.pipe';
 import { FormatterService } from '@core/formatter.service';
 
-fdescribe('DateTimePipe', () => {
+describe('DateTimePipe', () => {
   let formatterService, pipe;
 
   beforeEach(() => {

--- a/src/app/shared/map-overlay/shake-alert-overlay.ts
+++ b/src/app/shared/map-overlay/shake-alert-overlay.ts
@@ -100,13 +100,14 @@ const ShakeAlertOverlay = AsynchronousGeoJSONOverlay.extend({
     }, 0);
 
     // determine where to add the tooltip to each layer
-    try {
-      this.map.eachLayer(layer => {
+
+    this.map.eachLayer(layer => {
+      try {
         this.addTooltipToLayer(layer);
-      });
-    } catch (e) {
-      console.log(e);
-    }
+      } catch (e) {
+        console.log(e);
+      }
+    });
   },
 
   /**

--- a/src/app/shared/map-overlay/shake-alert-overlay.ts
+++ b/src/app/shared/map-overlay/shake-alert-overlay.ts
@@ -41,6 +41,32 @@ const ShakeAlertOverlay = AsynchronousGeoJSONOverlay.extend({
     setTimeout(() => {
       this.map.fitBounds(this.bounds);
     }, 0);
+
+    // Check if layer is circle and add tooltip for warning times
+    this.map.eachLayer(layer => {
+      if (
+        layer &&
+        layer.feature &&
+        layer.feature.geometry &&
+        layer.feature.geometry.type &&
+        layer.feature.geometry.type === 'Point' &&
+        layer.feature.properties &&
+        layer.feature.properties.radius
+      ) {
+        const bounds = layer.getBounds();
+        const latlng = {
+          lat: bounds._southWest.lat,
+          lng: layer.feature.geometry.coordinates[0]
+        };
+        const marker = L.marker(latlng).addTo(this.map);
+        // bind tooltip to the circle
+        marker.bindTooltip(layer.feature.properties.name, {
+          className: 'time-label',
+          direction: 'bottom',
+          permanent: true
+        });
+      }
+    });
   },
 
   /**

--- a/src/app/shared/map-overlay/shake-alert-overlay.ts
+++ b/src/app/shared/map-overlay/shake-alert-overlay.ts
@@ -80,6 +80,24 @@ const ShakeAlertOverlay = AsynchronousGeoJSONOverlay.extend({
           direction: 'top',
           permanent: true
         });
+      } else if (layer.feature.geometry.type === 'Polygon') {
+        const coordinates = layer.feature.geometry.coordinates;
+        // get first point on polygon
+        const latlng = {
+          lat: coordinates[0][0][1],
+          lng: coordinates[0][0][0]
+        };
+        const icon = L.icon({
+          iconSize: [0, 0],
+          iconUrl: 'empty'
+        });
+        const marker = L.marker(latlng, { icon: icon }).addTo(this.map);
+        // bind tooltip to the circle
+        marker.bindTooltip(layer.feature.properties.name, {
+          className: 'time-label',
+          direction: 'top',
+          permanent: true
+        });
       } else {
         layer.bindTooltip(layer.feature.properties.name, {
           className: 'time-label',

--- a/src/app/shared/map-overlay/shake-alert-overlay.ts
+++ b/src/app/shared/map-overlay/shake-alert-overlay.ts
@@ -45,7 +45,9 @@ const ShakeAlertOverlay = AsynchronousGeoJSONOverlay.extend({
   afterAdd: function() {
     this.bounds = this.getBounds();
     setTimeout(() => {
-      this.map.fitBounds(this.bounds);
+      this.map.fitBounds(this.bounds, {
+        padding: [30, 30]
+      });
     }, 0);
 
     // Check if layer is circle and add tooltip for warning times


### PR DESCRIPTION
fixes #1752 

You can use event `nc73143141` to see the labels displayed on the map