### PR TITLE
Fix event plotting discrepency on executive summary page

### DIFF
--- a/src/app/shared/interactive-map-overlays.pipe.ts
+++ b/src/app/shared/interactive-map-overlays.pipe.ts
@@ -28,16 +28,21 @@ export class InteractiveMapOverlaysPipe implements PipeTransform {
   lastEvent: Event = null;
   // pipes related to their product
   overlayCache: any = {};
-  /* tslint:disable:object-literal-sort-keys */
   overlayFactory: any = {
-    origin: new RegionInfoOverlaysPipe(),
-    // keep origin first, the rest go here:
-    shakemap: new ShakemapOverlaysPipe(),
-    'ground-failure': new GroundFailureOverlaysPipe(),
     dyfi: new DyfiOverlaysPipe(),
-    'finite-fault': new FiniteFaultOverlaysPipe()
+    'finite-fault': new FiniteFaultOverlaysPipe(),
+    'ground-failure': new GroundFailureOverlaysPipe(),
+    origin: new RegionInfoOverlaysPipe(),
+    shakemap: new ShakemapOverlaysPipe()
   };
-  /* tslint:enable:object-literal-sort-keys */
+  overlayFactoryOrder = [
+    'origin',
+    // keep origin first, the rest go here:
+    'shakemap',
+    'ground-failure',
+    'dyfi',
+    'finite-fault'
+  ];
   staticOverlays: L.Layer[] = [
     new LandscanPopulationOverlay(),
     new TectonicPlatesOverlay(),
@@ -138,7 +143,7 @@ export class InteractiveMapOverlaysPipe implements PipeTransform {
 
     // new array every time for change detection
     let overlays = [];
-    Object.keys(this.overlayFactory).forEach(type => {
+    this.overlayFactoryOrder.forEach(type => {
       overlays.push(...this.getOverlays(event, params, type));
     });
 

--- a/src/app/unique.spec.ts
+++ b/src/app/unique.spec.ts
@@ -1,22 +1,26 @@
-import { getUnique } from './unique';
+import { getUnique } from "./unique";
 
-describe('getUnique', () => {
-  it('should be defined', () => {
+describe("getUnique", () => {
+  it("should be defined", () => {
     expect(getUnique).toBeTruthy();
   });
 
-  it('should return unique values', () => {
-    const result = getUnique(['a', 'a', 'b']);
-    expect(result).toEqual(['a', 'b']);
+  it("should return unique values", () => {
+    const result = getUnique(["a", "a", "b"]);
+    expect(result).toEqual(["a", "b"]);
   });
 
-  it('should omit empty values', () => {
-    const result = getUnique(['', 'a']);
-    expect(result).toEqual(['a']);
+  it("should omit empty values", () => {
+    const result = getUnique(["", "a"]);
+    expect(result).toEqual(["a"]);
   });
 
-  it('should support objects', () => {
-    const result = getUnique([{ id: 'a' }, { id: 'b' }, { id: 'a' }]);
-    expect(result).toEqual([{ id: 'a' }, { id: 'b' }]);
+  it("should support objects", () => {
+    const result = getUnique([
+      { id: "a", other: 1 },
+      { id: "b" },
+      { id: "a", other: 2 }
+    ]);
+    expect(result).toEqual([{ id: "a", other: 1 }, { id: "b" }]);
   });
 });

--- a/src/app/unique.spec.ts
+++ b/src/app/unique.spec.ts
@@ -1,26 +1,26 @@
-import { getUnique } from "./unique";
+import { getUnique } from './unique';
 
-describe("getUnique", () => {
-  it("should be defined", () => {
+describe('getUnique', () => {
+  it('should be defined', () => {
     expect(getUnique).toBeTruthy();
   });
 
-  it("should return unique values", () => {
-    const result = getUnique(["a", "a", "b"]);
-    expect(result).toEqual(["a", "b"]);
+  it('should return unique values', () => {
+    const result = getUnique(['a', 'a', 'b']);
+    expect(result).toEqual(['a', 'b']);
   });
 
-  it("should omit empty values", () => {
-    const result = getUnique(["", "a"]);
-    expect(result).toEqual(["a"]);
+  it('should omit empty values', () => {
+    const result = getUnique(['', 'a']);
+    expect(result).toEqual(['a']);
   });
 
-  it("should support objects", () => {
+  it('should support objects', () => {
     const result = getUnique([
-      { id: "a", other: 1 },
-      { id: "b" },
-      { id: "a", other: 2 }
+      { id: 'a', other: 1 },
+      { id: 'b' },
+      { id: 'a', other: 2 }
     ]);
-    expect(result).toEqual([{ id: "a", other: 1 }, { id: "b" }]);
+    expect(result).toEqual([{ id: 'a', other: 1 }, { id: 'b' }]);
   });
 });

--- a/src/app/unique.ts
+++ b/src/app/unique.ts
@@ -4,7 +4,7 @@
  * @param items list of items.
  *        if items is an array of Objects,
  *        each objects `id` property is used to determine uniqueness,
- *        and the last object with a given `id` is returned.
+ *        and the first object with a given `id` is returned.
  * @return unique list of non-empty items.
  */
 export function getUnique(items: Array<any>): Array<any> {
@@ -17,7 +17,7 @@ export function getUnique(items: Array<any>): Array<any> {
     if (item.id) {
       key = item.id;
     }
-    if (key) {
+    if (key && !unique.hasOwnProperty(key)) {
       unique[key] = item;
     }
   });


### PR DESCRIPTION
Fixes #1768 , by choosing the origin EpicenterOverlay (which is first and preferred) over the shakemap EpicenterOverlay.

This may be all that is needed, although it changes the behavior of getUnique().  This appears to be the only place getUnique() is used with objects.