### PR TITLE
Bump version number to 1.29.0

### DIFF
--- a/code.json
+++ b/code.json
@@ -29,15 +29,15 @@
     "contact": {
       "email": "gs-haz_dev_team_group@usgs.gov"
     },
-    "version": "1.0.0",
+    "version": "1.29.0",
     "homepageURL": "https://github.com/usgs/earthquake-eventpages",
     "downloadURL": "https://github.com/usgs/earthquake-eventpages/archive/master.zip",
     "disclaimerURL": "https://github.com/usgs/earthquake-eventpages/blob/master/LICENSE.md",
     "vcs": "git",
     "date": {
       "created": "2013-10-29",
-      "lastModified": "2018-02-07",
-      "metadataLastUpdated": "2018-02-07"
+      "lastModified": "2020-04-24",
+      "metadataLastUpdated": "2020-04-24"
     }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthquake-eventpages",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "license": "MIT",
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Jenkins build is passing again, so prepping for tagged release.